### PR TITLE
사장님 ( 공고 등록 ) - '확인' 버튼을 누르면 공고 상세 페이지로 이동하는 기능 구현, '등록하기'버튼 디자인 수정

### DIFF
--- a/src/components/noticeRegister/Modal.tsx
+++ b/src/components/noticeRegister/Modal.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -10,6 +12,9 @@ import {
 import { Button } from "@/components/ui/button";
 
 function RegisterModal() {
+  const shopId = "c90e94dd-556b-4fad-9bef-f6c81cc4f242";
+  const noticeId = "1";
+
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
@@ -29,11 +34,13 @@ function RegisterModal() {
           </AlertDialogTitle>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogAction className="flex h-[4.2rem] w-[13.8rem] items-center justify-center gap-[1rem] rounded-md bg-primary px-[5.6rem] py-[1.2rem]">
-            <span className="text-center text-[1.4rem] font-medium not-italic leading-normal text-white">
-              확인
-            </span>
-          </AlertDialogAction>
+          <Link href={`/shops/${shopId}/notices/${noticeId}`}>
+            <AlertDialogAction className="flex h-[4.2rem] w-[13.8rem] items-center justify-center gap-[1rem] rounded-md bg-primary px-[5.6rem] py-[1.2rem]">
+              <span className="text-center text-[1.4rem] font-medium not-italic leading-normal text-white">
+                확인
+              </span>
+            </AlertDialogAction>
+          </Link>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/pages/shops/[shopId]/notices/[noticeId]/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/index.tsx
@@ -1,0 +1,5 @@
+function NoticeDetail() {
+  return <div>공고 상세</div>;
+}
+
+export default NoticeDetail;

--- a/src/pages/shops/[shopId]/notices/register/index.tsx
+++ b/src/pages/shops/[shopId]/notices/register/index.tsx
@@ -19,7 +19,7 @@ function NoticeRegister() {
   return (
     <>
       <Link href={"/notices"}>
-        <div className="relative h-[2rem] w-[10.8rem]">
+        <div className="relative h-[1.5rem] w-[8.1rem]">
           <Image
             src="/icons/logo.svg"
             layout="fill"
@@ -34,7 +34,7 @@ function NoticeRegister() {
             <div className="w-[37.5rem] gap-[0.8rem]">
               <div className="flex flex-col items-center justify-center">
                 <div className="flex w-full flex-col items-start gap-[0.8rem] px-[1.2rem] pb-[8rem] pt-[4rem]">
-                  <div className="flex h-[52.3rem] w-full flex-col items-center gap-[2.4rem]">
+                  <div className="flex w-full flex-col items-center gap-[2.4rem]">
                     <div className="flex w-full items-center justify-between self-stretch">
                       <h3 className="text-[2rem] font-bold not-italic leading-normal text-black">
                         공고 등록
@@ -51,7 +51,7 @@ function NoticeRegister() {
                         />
                       </Button>
                     </div>
-                    <div className="flex h-[52.3rem] w-full flex-col justify-end gap-[2rem]">
+                    <div className="flex w-full flex-col justify-end gap-[2rem]">
                       <div className="flex w-full flex-col items-start gap-[0.8rem]">
                         <FormField
                           control={form.control}


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: 공고 등록 페이지에서 등록한 공고의 상세 페이지로 이동하는 기능 필요
-

# 어떤 변화가 생겼나요?

- 이동할 공고 상세 페이지 컴포넌트 생성
- 아직 shopId와 noticeId 값이 없어서 임의로 직접 값을 부여해 페이지 이동 기능을 구현했음
- '등록하기' 버튼 height 수정

# 스크린샷(optional)

https://github.com/S2-P3-T5/Julge/assets/129366303/85299d4d-3870-4092-b450-259f605bd94e

<img width="351" alt="무제" src="https://github.com/S2-P3-T5/Julge/assets/129366303/9490e43a-80f3-4949-9924-5534957e0509">

