### PR TITLE
로그인: 로그인 페이지 구현

### DIFF
--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -1,0 +1,32 @@
+import { HTTPError } from "ky";
+
+import {
+  TokenDTO,
+  TokenRequestBody,
+  tokenResponseSchema,
+} from "@/apis/auth/schema";
+import { fetcher } from "@/apis/fetcher";
+import { extractTokenDTOFromResponse } from "@/helpers/auth";
+import { NotFoundRequestError } from "@/helpers/error";
+import { apiRouteUtils } from "@/routes";
+
+export const postToken = async ({
+  email,
+  password,
+}: TokenRequestBody): Promise<TokenDTO> =>
+  await fetcher
+    .post(apiRouteUtils.TOKEN, {
+      json: {
+        email,
+        password,
+      },
+    })
+    .json()
+    .then(tokenResponseSchema.parse)
+    .then(extractTokenDTOFromResponse)
+    .catch((err: HTTPError) => {
+      if (err.response.status === 404)
+        throw new NotFoundRequestError(err.message);
+
+      throw err;
+    });

--- a/src/apis/auth/schema.ts
+++ b/src/apis/auth/schema.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+import { createResponseSchema } from "@/apis/schema";
+import { userType } from "@/apis/user/schema";
+
+export const tokenRequestBody = z.object({
+  email: z.string(),
+  password: z.string(),
+});
+export type TokenRequestBody = z.infer<typeof tokenRequestBody>;
+
+export const userDTO = z.object({
+  id: z.string(),
+  email: z.string(),
+  type: userType,
+  name: z.optional(z.string()),
+  phone: z.optional(z.string()),
+  address: z.optional(z.string()),
+  bio: z.optional(z.string()),
+});
+export type UserDTO = z.infer<typeof userDTO>;
+
+export const tokenResponseSchema = createResponseSchema(
+  z.object({
+    item: z.object({
+      token: z.string(),
+      user: z.object({ item: userDTO, href: z.string() }),
+    }),
+  }),
+);
+export type TokenResponse = z.infer<typeof tokenResponseSchema>;
+
+export const tokenDTO = z.object({
+  token: z.string(),
+  user: userDTO,
+});
+export type TokenDTO = z.infer<typeof tokenDTO>;

--- a/src/apis/user/schema.ts
+++ b/src/apis/user/schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { createResponseSchema } from "@/apis/schema";
 
-const userType = z.enum(["employee", "employer"]);
+export const userType = z.enum(["employee", "employer"]);
 
 export const userDTO = z.object({
   id: z.string(),

--- a/src/components/signin/SigninForm.tsx
+++ b/src/components/signin/SigninForm.tsx
@@ -1,0 +1,73 @@
+import ValidationErrorDialog from "@/components/signin/ValidationErrorDialog";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import useSigninForm from "@/hooks/useSigninForm";
+
+export default function SigninForm() {
+  const { form, onSubmit, rules, handlers } = useSigninForm();
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="flex w-full flex-col gap-[2.8rem]"
+      >
+        <FormField
+          control={form.control}
+          name="email"
+          rules={rules.email}
+          render={({ field }) => (
+            <FormItem className="w-full">
+              <FormLabel className="text-[1.6rem]">이메일</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="이메일을 입력해주세요."
+                  {...field}
+                  onBlur={handlers.email.onBlur}
+                  className="mt-[0.8rem] w-full focus-visible:ring-gray-40 data-[invalid]:border-red-40"
+                />
+              </FormControl>
+              <FormMessage className="absolute text-[1.2rem]" />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="password"
+          rules={rules.password}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-[1.6rem]">비밀번호</FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  placeholder="비밀번호를 입력해주세요."
+                  {...field}
+                  onBlur={handlers.password.onBlur}
+                  className="mt-[0.8rem] w-full focus-visible:ring-gray-40"
+                />
+              </FormControl>
+              <FormMessage className="absolute text-[1.2rem]" />
+            </FormItem>
+          )}
+        />
+        <Button
+          type="submit"
+          disabled={!form.formState.isValid}
+          className="h-max rounded-[0.6rem] py-[1.6rem] text-[1.6rem]"
+        >
+          로그인 하기
+        </Button>
+        <ValidationErrorDialog />
+      </form>
+    </Form>
+  );
+}

--- a/src/components/signin/ValidationErrorDialog.tsx
+++ b/src/components/signin/ValidationErrorDialog.tsx
@@ -1,0 +1,42 @@
+import { useContext } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { DialogActionContext, DialogContext } from "@/providers/DialogProvider";
+import { fontPretendard } from "@/styles/fonts";
+
+export default function ValidationErrorDialog() {
+  const opened = useContext(DialogContext);
+  const { close, toggle } = useContext(DialogActionContext);
+
+  // TODO: "비밀번호가 일치하지 않습니다."를 errorMessage로 바꾸고 외부에서 주입받도록 변경. errorMessage는 에러 객체의 message.
+  return (
+    <Dialog open={opened} onOpenChange={toggle}>
+      <DialogContent
+        className={cn(
+          "flex h-[22.4rem] flex-col items-center justify-end gap-[4.8rem] rounded-[0.8rem] p-[3.2rem]",
+          fontPretendard.variable,
+        )}
+      >
+        <DialogDescription className="text-[1.6rem] text-black">
+          비밀번호가 일치하지 않습니다.
+        </DialogDescription>
+        <DialogFooter>
+          <Button
+            type="button"
+            onClick={close}
+            className="h-[4.2rem] w-[13.8rem] rounded-[0.6rem] font-pretendard text-[1.4rem]"
+          >
+            확인
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/helpers/auth.ts
+++ b/src/helpers/auth.ts
@@ -1,0 +1,13 @@
+import { TokenDTO, TokenResponse } from "@/apis/auth/schema";
+
+export const extractTokenDTOFromResponse = (res: TokenResponse): TokenDTO => {
+  const {
+    item: { token, user },
+  } = res;
+  const { item: userDTO } = user;
+
+  return {
+    token,
+    user: userDTO,
+  };
+};

--- a/src/helpers/error.ts
+++ b/src/helpers/error.ts
@@ -6,3 +6,12 @@ export class ConflictRequestError {
     this.message = message;
   }
 }
+
+export class NotFoundRequestError {
+  status = 404;
+  message;
+
+  constructor(message: string) {
+    this.message = message;
+  }
+}

--- a/src/hooks/useSigninForm.ts
+++ b/src/hooks/useSigninForm.ts
@@ -1,0 +1,56 @@
+import { SubmitHandler, useForm } from "react-hook-form";
+
+import { errorMessage, PASSWORD_MIN_LENGTH } from "@/helpers/validation";
+import { REGEX_EMAIL } from "@/lib/constants";
+import { useSignin } from "@/queries/auth";
+import { FormRules } from "@/types/form";
+import { SigninFormField } from "@/types/signin";
+
+export default function useSigninForm() {
+  const form = useForm<SigninFormField>({
+    values: { email: "", password: "" },
+  });
+  const { mutate } = useSignin();
+
+  const onSubmit: SubmitHandler<SigninFormField> = ({ email, password }) => {
+    mutate({ email, password });
+  };
+
+  const rules: FormRules<SigninFormField> = {
+    email: {
+      required: {
+        value: true,
+        message: errorMessage.REQUIRED_EMAIL,
+      },
+      pattern: {
+        value: REGEX_EMAIL,
+        message: errorMessage.INVALID_EMAIL_FORMAT,
+      },
+    },
+    password: {
+      required: {
+        value: true,
+        message: errorMessage.REQUIRED_PASSWORD,
+      },
+      minLength: {
+        value: PASSWORD_MIN_LENGTH,
+        message: errorMessage.MIN_LENGTH_PASSWORD,
+      },
+    },
+  };
+
+  const handlers = {
+    email: {
+      onBlur: () => {
+        form.trigger("email");
+      },
+    },
+    password: {
+      onBlur: () => {
+        form.trigger(["password"]);
+      },
+    },
+  };
+
+  return { form, onSubmit, rules, handlers };
+}

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,0 +1,38 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import SigninForm from "@/components/signin/SigninForm";
+import DialogProvider from "@/providers/DialogProvider";
+import { PAGE_ROUTES } from "@/routes";
+
+export default function Page() {
+  return (
+    <DialogProvider>
+      <div className="flex min-h-screen items-center justify-center">
+        <section className="flex w-full max-w-[35rem] flex-col items-center gap-[4rem] text-[1.6rem] text-black">
+          <Link href={PAGE_ROUTES.NOTICES} className="w-max">
+            <Image
+              src="/icons/logo.svg"
+              alt="로고 이미지"
+              width={248}
+              height={48}
+              className="h-[4rem] w-[20.8rem]"
+            />
+          </Link>
+          <div className="flex w-full flex-col items-center">
+            <SigninForm />
+            <div className="mt-[2rem]">
+              회원이 아니신가요?{" "}
+              <Link
+                href={PAGE_ROUTES.SIGNUP}
+                className="text-violet-800 underline underline-offset-4"
+              >
+                회원가입하기
+              </Link>
+            </div>
+          </div>
+        </section>
+      </div>
+    </DialogProvider>
+  );
+}

--- a/src/queries/auth.ts
+++ b/src/queries/auth.ts
@@ -1,0 +1,27 @@
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/router";
+import { useContext } from "react";
+
+import { postToken } from "@/apis/auth";
+import { TokenRequestBody } from "@/apis/auth/schema";
+import { NotFoundRequestError } from "@/helpers/error";
+import { DialogActionContext } from "@/providers/DialogProvider";
+import { PAGE_ROUTES } from "@/routes";
+
+export const useSignin = () => {
+  const router = useRouter();
+  const { open: openValidationErrorDialog } = useContext(DialogActionContext);
+
+  const mutation = useMutation({
+    mutationFn: ({ email, password }: TokenRequestBody) =>
+      postToken({ email, password }),
+    onSuccess: () => {
+      router.push(PAGE_ROUTES.NOTICES);
+    },
+    onError: (err) => {
+      if (err instanceof NotFoundRequestError) openValidationErrorDialog();
+    },
+  });
+
+  return mutation;
+};

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -9,6 +9,7 @@ export const API_ROUTE = process.env.NEXT_PUBLIC_API_ENDPOINT;
 export const apiRouteUtils = {
   USERS: "users",
   SHOPS: "shops",
+  TOKEN: "token",
   parseNoticeRegisterURL: (shopId: string) =>
     `/shops/${shopId}/notices/register`,
 };

--- a/src/types/signin.ts
+++ b/src/types/signin.ts
@@ -1,0 +1,4 @@
+export type SigninFormField = {
+  email: string;
+  password: string;
+};


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #62 #63 #65
-

# 어떤 변화가 생겼나요?

- 로그인 페이지를 구현했습니다. 회원가입 페이지에서 타입과 비밀번호 확인 인풋을 제외한 것과 같아서 pr을 조금 크게 잡았습니다.
- 이메일 혹은 비밀번호가 다를 경우 "비밀번호가 일치하지 않습니다." 모달창을 띄웁니다.
  - 피그마에는 "비밀번호가 일치
하지 않습니다"로 고정인데 이메일이 다를 경우도 있으니 에러 메세지를 파싱해서 받는 모달로 바꿔야 할 것 같습니다.

# 스크린샷(optional)
<img width="329" alt="스크린샷 2024-01-28 오전 2 22 13" src="https://github.com/S2-P3-T5/Julge/assets/29909393/674082f7-6fc5-4a2c-8712-057753accc12">
<img width="329" alt="스크린샷 2024-01-28 오전 2 24 38" src="https://github.com/S2-P3-T5/Julge/assets/29909393/31918e29-9a44-43ef-9442-74bf895b46eb">