### PR TITLE
유저: 로그인 시 유저 객체 전역상태로 저장

### DIFF
--- a/src/helpers/auth.ts
+++ b/src/helpers/auth.ts
@@ -1,4 +1,5 @@
-import { TokenDTO, TokenResponse } from "@/apis/auth/schema";
+import { TokenDTO, TokenResponse, UserDTO } from "@/apis/auth/schema";
+import { User } from "@/types/user";
 
 export const extractTokenDTOFromResponse = (res: TokenResponse): TokenDTO => {
   const {
@@ -11,3 +12,9 @@ export const extractTokenDTOFromResponse = (res: TokenResponse): TokenDTO => {
     user: userDTO,
   };
 };
+
+export const mapUserDTOToUser = (udto: UserDTO): User => ({
+  id: udto.id,
+  email: udto.email,
+  type: udto.type,
+});

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,6 +10,7 @@ import type { AppProps } from "next/app";
 import { useState } from "react";
 
 import { cn } from "@/lib/utils";
+import UserProvider from "@/providers/UserProvider";
 import { fontSpoqaHanSansNeo } from "@/styles/fonts";
 
 export default function App({ Component, pageProps }: AppProps) {
@@ -27,14 +28,16 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <HydrationBoundary state={pageProps.dehydratedState}>
-        <main
-          className={cn(
-            "min-h-screen bg-background font-spoqa antialiased",
-            fontSpoqaHanSansNeo.variable,
-          )}
-        >
-          <Component {...pageProps} />
-        </main>
+        <UserProvider>
+          <main
+            className={cn(
+              "min-h-screen bg-background font-spoqa antialiased",
+              fontSpoqaHanSansNeo.variable,
+            )}
+          >
+            <Component {...pageProps} />
+          </main>
+        </UserProvider>
       </HydrationBoundary>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -2,8 +2,8 @@ import { createContext, PropsWithChildren, useState } from "react";
 
 import { User } from "@/types/user";
 
-const UserContext = createContext<User | null>(null);
-const UserActionContext = createContext({
+export const UserContext = createContext<User | null>(null);
+export const UserActionContext = createContext({
   login: (user: User) => {},
   logout: () => {},
 });

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -1,0 +1,29 @@
+import { createContext, PropsWithChildren, useState } from "react";
+
+import { User } from "@/types/user";
+
+const UserContext = createContext<User | null>(null);
+const UserActionContext = createContext({
+  login: (user: User) => {},
+  logout: () => {},
+});
+
+export default function UserProvider({ children }: PropsWithChildren) {
+  const [user, setUser] = useState<User | null>(null);
+
+  const login = (user: User) => {
+    setUser(user);
+  };
+
+  const logout = () => {
+    setUser(null);
+  };
+
+  return (
+    <UserContext.Provider value={user}>
+      <UserActionContext.Provider value={{ login, logout }}>
+        {children}
+      </UserActionContext.Provider>
+    </UserContext.Provider>
+  );
+}

--- a/src/queries/auth.ts
+++ b/src/queries/auth.ts
@@ -4,18 +4,23 @@ import { useContext } from "react";
 
 import { postToken } from "@/apis/auth";
 import { TokenRequestBody } from "@/apis/auth/schema";
+import { mapUserDTOToUser } from "@/helpers/auth";
 import { NotFoundRequestError } from "@/helpers/error";
 import { DialogActionContext } from "@/providers/DialogProvider";
+import { UserActionContext } from "@/providers/UserProvider";
 import { PAGE_ROUTES } from "@/routes";
 
 export const useSignin = () => {
   const router = useRouter();
   const { open: openValidationErrorDialog } = useContext(DialogActionContext);
+  const { login } = useContext(UserActionContext);
 
   const mutation = useMutation({
     mutationFn: ({ email, password }: TokenRequestBody) =>
       postToken({ email, password }),
-    onSuccess: () => {
+    onSuccess: ({ user: userDTO }) => {
+      const user = mapUserDTOToUser(userDTO);
+      login(user);
       router.push(PAGE_ROUTES.NOTICES);
     },
     onError: (err) => {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,5 +1,6 @@
 export type User = {
   id: string;
+  email: string;
   type: UserType;
 };
 


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #69 
- 로그인을 후 화면에서 유저 아이디와 타입이 전역적으로 필요함. 

# 어떤 변화가 생겼나요?

- context, useState로 유저 전역 상태 추가
- 로그인 시 응답으로 받은 유저 객체를 유저 컨텍스트에 저장(기본 값: null)
- 필드
  - id: 유저 아이디(uuid)
  - email: 유저 이메일(아이디로 입력한 값)
  - type: 사장님 | 알바님

# 스크린샷(optional)
```
export const UserContext = createContext<User | null>(null);
export const UserActionContext = createContext({
  login: (user: User) => {},
  logout: () => {},
});
```
```
const [user, setUser] = useState<User | null>(null);

  const login = (user: User) => {
    setUser(user);
  };

  const logout = () => {
    setUser(null);
  };
```