### PR TITLE
사장님 : (가게 정보 상세) 가게 정보 상세 카드 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,12 @@ const nextConfig = {
         port: "",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "i.ibb.co",
+        port: "",
+        pathname: "/**",
+      },
     ],
   },
 };

--- a/src/apis/shops/index.ts
+++ b/src/apis/shops/index.ts
@@ -23,3 +23,14 @@ export const postImages = async (token: string, name: string) => {
 export const putPresignedURL = async (presignedURL: string, img: File) => {
   await ky.put(presignedURL, { body: img });
 };
+
+// TODO: 에러처리
+export const getShopsData = async (shopId: string) => {
+  try {
+    const response = await fetcher.get(apiRouteUtils.parseShopsURL(shopId));
+    const result = await response.json();
+    return result;
+  } catch (e: any) {
+    throw e;
+  }
+};

--- a/src/components/shop/ShopDataCard.tsx
+++ b/src/components/shop/ShopDataCard.tsx
@@ -1,0 +1,65 @@
+import Image from "next/image";
+import Link from "next/link";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { PAGE_ROUTES } from "@/routes";
+
+interface ShopDataCardProps {
+  name: string;
+  address1: string;
+  description: string;
+  imageUrl: string;
+}
+
+// TODO : props 재설정
+export default function ShopDataCard({
+  shopId,
+}: {
+  shopId: string | string[] | undefined;
+}) {
+  const mockData = {
+    name: "도토리 식당",
+    address1: "서울시 송파구",
+    description: "도토리 없는 도토리 식당입니다.",
+    imageUrl: "https://i.ibb.co/0V2PH9f/default.jpg",
+  };
+
+  return (
+    <>
+      {typeof shopId === "string" && (
+        <Card className="w-[350px] p-[20px]">
+          <Image
+            src={mockData.imageUrl}
+            width="311"
+            height="178"
+            alt="가게이미지"
+          />
+          <CardHeader>
+            <div>식당</div>
+            <CardTitle>{mockData.name}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <span>{mockData.address1}</span>
+            <p>{mockData.description}</p>
+          </CardContent>
+          <CardFooter className="flex gap-[10px]">
+            <Button>편집하기</Button>
+            <Button asChild>
+              <Link href={PAGE_ROUTES.parseNoticeRegisterURL(shopId)}>
+                공고 등록하기
+              </Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      )}
+    </>
+  );
+}

--- a/src/components/shop/ShopDataCard.tsx
+++ b/src/components/shop/ShopDataCard.tsx
@@ -13,42 +13,34 @@ import {
 import { PAGE_ROUTES } from "@/routes";
 
 interface ShopDataCardProps {
-  name: string;
-  address1: string;
-  description: string;
-  imageUrl: string;
+  shopId: string | string[] | undefined;
+  shopData: {
+    name: string;
+    address1: string;
+    description: string;
+    imageUrl: string;
+  };
 }
 
 // TODO : props 재설정
-export default function ShopDataCard({
-  shopId,
-}: {
-  shopId: string | string[] | undefined;
-}) {
-  const mockData = {
-    name: "도토리 식당",
-    address1: "서울시 송파구",
-    description: "도토리 없는 도토리 식당입니다.",
-    imageUrl: "https://i.ibb.co/0V2PH9f/default.jpg",
-  };
-
+export default function ShopDataCard({ shopId, shopData }: ShopDataCardProps) {
   return (
     <>
       {typeof shopId === "string" && (
         <Card className="w-[350px] p-[20px]">
           <Image
-            src={mockData.imageUrl}
+            src={shopData.imageUrl}
             width="311"
             height="178"
             alt="가게이미지"
           />
           <CardHeader>
             <div>식당</div>
-            <CardTitle>{mockData.name}</CardTitle>
+            <CardTitle>{shopData.name}</CardTitle>
           </CardHeader>
           <CardContent>
-            <span>{mockData.address1}</span>
-            <p>{mockData.description}</p>
+            <span>{shopData.address1}</span>
+            <p>{shopData.description}</p>
           </CardContent>
           <CardFooter className="flex gap-[10px]">
             <Button>편집하기</Button>

--- a/src/pages/shops/[shopId]/index.tsx
+++ b/src/pages/shops/[shopId]/index.tsx
@@ -29,6 +29,7 @@ type dataType = {
 };
 
 export default function Shop() {
+  const [isLoading, setIsLoading] = useState(true);
   const [shopData, setShopData] = useState<dataType | null>(null);
   const hasNotice = false; //기능 구현 전 임시 설정
   const router = useRouter();
@@ -40,11 +41,15 @@ export default function Shop() {
         // TODO : result type 재설정
         const result: any = await getShopsData(shopId);
         setShopData(result.item);
+        setIsLoading(false);
       })();
     }
   }, [shopId]);
 
-  return shopData ? (
+  return isLoading ? (
+    //TODO : loading 차후 구현
+    <div className="text-[60px]">로딩중</div>
+  ) : shopData ? (
     <div>
       <ShopDataCard shopId={shopId} shopData={shopData} />
       {hasNotice ? <div>공고 리스트</div> : <div>공고 등록하기 카드</div>}

--- a/src/pages/shops/[shopId]/index.tsx
+++ b/src/pages/shops/[shopId]/index.tsx
@@ -1,7 +1,20 @@
+import { useRouter } from "next/router";
+
 import EmptyShopCard from "@/components/shop/EmptyShopCard";
+import ShopDataCard from "@/components/shop/ShopDataCard";
 
 export default function Shop() {
-  const hasShopsInfo = false; // 기능 구현 전 임시 설정
+  const hasShopsInfo = true; // 기능 구현 전 임시 설정
+  const hasNotice = false; //기능 구현 전 임시 설정
+  const router = useRouter();
+  const { shopId } = router.query;
 
-  return !hasShopsInfo && <EmptyShopCard />;
+  return hasShopsInfo ? (
+    <div>
+      <ShopDataCard shopId={shopId} />
+      {hasNotice ? <div>공고 리스트</div> : <div>공고 등록하기 카드</div>}
+    </div>
+  ) : (
+    <EmptyShopCard />
+  );
 }

--- a/src/pages/shops/[shopId]/index.tsx
+++ b/src/pages/shops/[shopId]/index.tsx
@@ -1,17 +1,52 @@
 import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 
+import { getShopsData } from "@/apis/shops";
 import EmptyShopCard from "@/components/shop/EmptyShopCard";
 import ShopDataCard from "@/components/shop/ShopDataCard";
 
+type dataType = {
+  id: "string";
+  name: "string";
+  category: "string";
+  address1: "string";
+  address2: "string";
+  description: "string";
+  imageUrl: "string";
+  originalHourlyPay: "number";
+  user: {
+    item: {
+      id: "string";
+      email: "string";
+      type: "employer | employee";
+      name?: "string";
+      phone?: "string";
+      address?: "string";
+      bio?: "string";
+    };
+    href: "string";
+  };
+};
+
 export default function Shop() {
-  const hasShopsInfo = true; // 기능 구현 전 임시 설정
+  const [shopData, setShopData] = useState<dataType | null>(null);
   const hasNotice = false; //기능 구현 전 임시 설정
   const router = useRouter();
   const { shopId } = router.query;
 
-  return hasShopsInfo ? (
+  useEffect(() => {
+    if (typeof shopId === "string") {
+      (async () => {
+        // TODO : result type 재설정
+        const result: any = await getShopsData(shopId);
+        setShopData(result.item);
+      })();
+    }
+  }, [shopId]);
+
+  return shopData ? (
     <div>
-      <ShopDataCard shopId={shopId} />
+      <ShopDataCard shopId={shopId} shopData={shopData} />
       {hasNotice ? <div>공고 리스트</div> : <div>공고 등록하기 카드</div>}
     </div>
   ) : (

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,6 +4,8 @@ export const PAGE_ROUTES = {
   NOTICES: "/notices",
   SHOPS_REGISTER: "/shops/register",
   parseShopsURL: (shopId: string) => `/shops/${shopId}`,
+  parseNoticeRegisterURL: (shopId: string) =>
+    `/shops/${shopId}/notices/register`,
 };
 
 export const API_ROUTE = process.env.NEXT_PUBLIC_API_ENDPOINT;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -16,4 +16,5 @@ export const apiRouteUtils = {
   IMAGES: "images",
   parseNoticeRegisterURL: (shopId: string) =>
     `/shops/${shopId}/notices/register`,
+  parseShopsURL: (shopId: string) => `shops/${shopId}`,
 };


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #72 
- 사장님 페이지에서 가게 정보가 있을 시에 가게 정보가 표시되어야 한다.

# 어떤 변화가 생겼나요?
-가게 상세 정보 표시 카드 구현
- 등록하기 버튼으로 등록페이지 이동
- 편집하기 버튼 차후 구현
- Loading 임시 구현

# 스크린샷(optional)

![pr3](https://github.com/S2-P3-T5/Julge/assets/144401634/eca07b43-04c8-4944-8eee-34db939ca056)
