### PR TITLE
사장님 -(공고 상세 페이지): 승인하기, 거절하기 버튼과 거절완료, 승인완료 뱃지 디자인 구현

### DIFF
--- a/src/components/noticeDetail/Badge.tsx
+++ b/src/components/noticeDetail/Badge.tsx
@@ -1,0 +1,47 @@
+import Image from "next/image";
+
+import { Badge } from "@/components/ui/badge";
+
+export const ApproveBadge = () => {
+  return (
+    <Badge
+      variant="secondary"
+      className="flex items-center rounded-[2rem] bg-blue-10 px-[1rem] py-[0.6rem]"
+    >
+      <span className="text-[1.2rem] font-normal not-italic leading-[1.6rem] text-blue-20">
+        승인 완료
+      </span>
+    </Badge>
+  );
+};
+
+export const RejectBadge = () => {
+  return (
+    <Badge
+      variant="secondary"
+      className="flex items-center rounded-[2rem] bg-red-10 px-[1rem] py-[0.6rem]"
+    >
+      <span className="text-[1.2rem] font-normal not-italic leading-[1.6rem] text-red-40">
+        거절
+      </span>
+    </Badge>
+  );
+};
+
+export const HighHourlyWageBadge = () => {
+  return (
+    <div className="flex h-[2.4rem] w-[13.1rem] items-center gap-[0.2rem] rounded-[2rem] bg-primary px-[0.8rem] py-[0.4rem]">
+      <span className="items-center text-[1.2rem] font-normal not-italic leading-[1.6rem] text-white">
+        기존 시급보다 50%
+      </span>
+      <div className="relative flex h-[1.6rem] w-[1.6rem] items-center justify-center">
+        <Image
+          src="/icons/arrow_up_bold.svg"
+          alt="윗방향 화살표 이미지"
+          layout="fill"
+          objectFit="contain"
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/noticeDetail/Buttons.tsx
+++ b/src/components/noticeDetail/Buttons.tsx
@@ -1,0 +1,21 @@
+import { Button } from "@/components/ui/button";
+
+export const RejectButton = () => {
+  return (
+    <Button className="flex h-[3.2rem] w-[6.9rem] gap-[0.8rem] rounded-[0.6rem] border-[0.1rem] border-primary bg-white px-[1.2rem] py-[0.8rem]">
+      <span className="text-center text-[1.2rem] font-normal not-italic leading-[1.6rem] text-primary">
+        거절하기
+      </span>
+    </Button>
+  );
+};
+
+export const ApproveButton = () => {
+  return (
+    <Button className="flex h-[3.2rem] w-[6.9rem] gap-[0.8rem] rounded-[0.6rem] border-[0.1rem] border-blue-20 bg-white px-[1.2rem] py-[0.8rem]">
+      <span className="text-center text-[1.2rem] font-normal not-italic leading-[1.6rem] text-blue-20">
+        승인하기
+      </span>
+    </Button>
+  );
+};

--- a/src/components/noticeDetail/Buttons.tsx
+++ b/src/components/noticeDetail/Buttons.tsx
@@ -1,5 +1,15 @@
 import { Button } from "@/components/ui/button";
 
+export const EditNoticeButton = () => {
+  return (
+    <Button className="h-[3.8rem] w-full rounded-[0.6rem] border-[0.1rem] border-primary bg-white px-[2rem] py-[1rem]">
+      <span className="text-center text-[1.4rem] font-bold not-italic leading-normal text-primary">
+        공고 편집하기
+      </span>
+    </Button>
+  );
+};
+
 export const RejectButton = () => {
   return (
     <Button className="flex h-[3.2rem] w-[6.9rem] gap-[0.8rem] rounded-[0.6rem] border-[0.1rem] border-primary bg-white px-[1.2rem] py-[0.8rem]">

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/pages/shops/[shopId]/notices/[noticeId]/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/index.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 
+import { ApproveButton, RejectButton } from "@/components/noticeDetail/Buttons";
 import HighHourlyWageBadge from "@/components/noticeDetail/HighHourlyWageBadge";
 import NoticeDetailPagination from "@/components/noticeDetail/NoticeDetailPagination";
 import { Button } from "@/components/ui/button";
@@ -120,7 +121,10 @@ function NoticeDetail() {
                 {"최선을 다하겠습니다"}
               </span>
             </div>
-            <div className="col-span-1 flex items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-t-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem]"></div>
+            <div className="col-span-1 flex items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-t-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem]">
+              <RejectButton />
+              <ApproveButton />
+            </div>
             <div className="col-span-1 flex items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-r-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem]">
               <span className="text-black-50 scroll-auto text-[1.4rem] font-normal not-italic leading-[2.2rem]">
                 {"서혜진"}

--- a/src/pages/shops/[shopId]/notices/[noticeId]/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/index.tsx
@@ -1,11 +1,15 @@
 import Image from "next/image";
 
 import {
+  ApproveBadge,
+  HighHourlyWageBadge,
+  RejectBadge,
+} from "@/components/noticeDetail/Badge";
+import {
   ApproveButton,
   EditNoticeButton,
   RejectButton,
 } from "@/components/noticeDetail/Buttons";
-import HighHourlyWageBadge from "@/components/noticeDetail/HighHourlyWageBadge";
 import NoticeDetailPagination from "@/components/noticeDetail/NoticeDetailPagination";
 
 function NoticeDetail() {
@@ -130,18 +134,27 @@ function NoticeDetail() {
                 {"서혜진"}
               </span>
             </div>
-            <div className="col-span-1 flex items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem]"></div>
             <div className="md:col-span-1 md:block hidden items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-r-[0.1rem] bg-white px-[0.8rem] py-[1.2rem]">
               <span className="text-black-50 scroll-auto truncate text-[1.6rem] font-normal not-italic leading-[2.6rem]">
                 {"최선을 다하겠습니다"}
               </span>
+            </div>
+            <div className="col-span-1 flex items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem]">
+              <ApproveBadge />
             </div>
             <div className="col-span-1 flex items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-r-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem]">
               <span className="text-black-50 scroll-auto text-[1.4rem] font-normal not-italic leading-[2.2rem]">
                 {"주진혁"}
               </span>
             </div>
-            <div className="col-span-1 flex items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem]"></div>
+            <div className="md:col-span-1 md:block hidden items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-r-[0.1rem] bg-white px-[0.8rem] py-[1.2rem]">
+              <span className="text-black-50 scroll-auto truncate text-[1.6rem] font-normal not-italic leading-[2.6rem]">
+                {"최선을 다하겠습니다"}
+              </span>
+            </div>
+            <div className="col-span-1 flex items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem]">
+              <RejectBadge />
+            </div>
             <div className="col-span-1 flex items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-r-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem]">
               <span className="text-black-50 scroll-auto text-[1.4rem] font-normal not-italic leading-[2.2rem]">
                 {"장민혁"}

--- a/src/pages/shops/[shopId]/notices/[noticeId]/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/index.tsx
@@ -1,9 +1,13 @@
 import Image from "next/image";
 
-import { ApproveButton, RejectButton } from "@/components/noticeDetail/Buttons";
+import {
+  ApproveButton,
+  EditNoticeButton,
+  RejectButton,
+} from "@/components/noticeDetail/Buttons";
 import HighHourlyWageBadge from "@/components/noticeDetail/HighHourlyWageBadge";
 import NoticeDetailPagination from "@/components/noticeDetail/NoticeDetailPagination";
-import { Button } from "@/components/ui/button";
+
 function NoticeDetail() {
   return (
     <div className="flex flex-col items-center justify-start">
@@ -77,11 +81,7 @@ function NoticeDetail() {
                   {"용준좌가 적극 추천한 돈까스집"}
                 </span>
               </div>
-              <Button className="h-[3.8rem] w-full rounded-[0.6rem] border-[0.1rem] border-primary bg-white px-[2rem] py-[1rem]">
-                <span className="text-center text-[1.4rem] font-bold not-italic leading-normal text-primary">
-                  공고 편집하기
-                </span>
-              </Button>
+              <EditNoticeButton />
             </div>
           </div>
         </div>


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: 등록한 공고의 신청자 목록에서 승인, 거절하기 기능에 필요한 각 뱃지들이 필요
- 원래 상태table의 초기모습은 각 칸에 거절하기, 승인하기 버튼만 나란히 존재해야하지만, 디자인 구현을 보여주기 위해 임시로 거절 혹은 승인이 된 상태라 생각하고 뱃지를 하나씩 집어넣음

# 어떤 변화가 생겼나요?

- /components/noticeDetail 안에 Badge파일을 만들어서 공고 상세 페이지에서 쓰이는 뱃지들을 모아서 따로 export하도록 수정함
- 승인, 거절하기 뱃지 디자인 생성

# 스크린샷(optional)
![무제 3](https://github.com/S2-P3-T5/Julge/assets/129366303/c5a7ad50-ee50-4088-907c-73178982c508)
