### PR TITLE
사장님-(공고 등록 페이지, 공고 상세 페이지): url 일부 수정, 닫기 버튼 button 타입 추가

### DIFF
--- a/src/components/noticeRegister/Modal.tsx
+++ b/src/components/noticeRegister/Modal.tsx
@@ -34,7 +34,7 @@ function RegisterModal() {
           </AlertDialogTitle>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <Link href={`/shops/${shopId}/notices/${noticeId}`}>
+          <Link href={`shops/${shopId}/notices/${noticeId}`}>
             <AlertDialogAction className="flex h-[4.2rem] w-[13.8rem] items-center justify-center gap-[1rem] rounded-md bg-primary px-[5.6rem] py-[1.2rem]">
               <span className="text-center text-[1.4rem] font-medium not-italic leading-normal text-white">
                 확인

--- a/src/pages/shops/[shopId]/notices/register/index.tsx
+++ b/src/pages/shops/[shopId]/notices/register/index.tsx
@@ -40,6 +40,7 @@ function NoticeRegister() {
                         공고 등록
                       </h3>
                       <Button
+                        type="button"
                         variant="ghost"
                         className="relative h-[2.4rem] w-[2.4rem]"
                       >

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -13,5 +13,5 @@ export const apiRouteUtils = {
   TOKEN: "token",
   IMAGES: "images",
   parseNoticeRegisterURL: (shopId: string) =>
-    `/shops/${shopId}/notices/register`,
+    `shops/${shopId}/notices/register`,
 };


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: 공고 등록 페이지, 공고 상세 페이지 url 수정
- 공고 등록 페이지의 닫기 버튼에 type이 누락

# 어떤 변화가 생겼나요?

- 공고 등록 페이지, 공고 상세 페이지 url 수정
-  `/shops/${shopId}/notices/register`, `/shops/${shopId}/notices/${noticeId}`
에서 shops 앞 '/' 제거
- 공고 등록 페이지의 공고 목록 닫기 버튼에 type 추가

# 스크린샷(optional)
