### PR TITLE
사장님 - (공고 등록 페이지): 공고 등록 input 필수값 유효성 검사 로직 추가, '등록하기' 눌렀을 때 리스폰스 응답을 잘 받을 때만 '등록 완료' 모달창이 나오도록 수정

### DIFF
--- a/src/apis/shop/index.ts
+++ b/src/apis/shop/index.ts
@@ -16,9 +16,7 @@ export const postNoticeRegistration = async ({
 }: NoticeRegistrationRequestBody): Promise<NoticeRegistrationDTO> =>
   await fetcher
     .post(
-      apiRouteUtils.parseNoticeRegisterURL(
-        "c90e94dd-556b-4fad-9bef-f6c81cc4f242",
-      ),
+      apiRouteUtils.parseShopNoticesURL("c90e94dd-556b-4fad-9bef-f6c81cc4f242"),
       {
         json: {
           hourlyPay,

--- a/src/components/noticeRegister/Modal.tsx
+++ b/src/components/noticeRegister/Modal.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 
-function RegisterModal() {
+function RegisterModal({ form }: any) {
   const shopId = "c90e94dd-556b-4fad-9bef-f6c81cc4f242";
   const noticeId = "1";
 
@@ -20,6 +20,7 @@ function RegisterModal() {
       <AlertDialogTrigger asChild>
         <Button
           type="submit"
+          disabled={!form.formState.isValid}
           className="flex h-[4.8rem] items-center justify-center gap-[0.8rem] self-stretch rounded-md bg-primary px-[13.6rem] py-[1.4rem]"
         >
           <span className="text-center text-[1.6rem] font-bold leading-5 text-white">
@@ -34,7 +35,7 @@ function RegisterModal() {
           </AlertDialogTitle>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <Link href={`shops/${shopId}/notices/${noticeId}`}>
+          <Link href={`/shops/${shopId}/notices/${noticeId}`}>
             <AlertDialogAction className="flex h-[4.2rem] w-[13.8rem] items-center justify-center gap-[1rem] rounded-md bg-primary px-[5.6rem] py-[1.2rem]">
               <span className="text-center text-[1.4rem] font-medium not-italic leading-normal text-white">
                 확인

--- a/src/components/noticeRegister/Modal.tsx
+++ b/src/components/noticeRegister/Modal.tsx
@@ -10,24 +10,15 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { useNoticeRegistration } from "@/queries/shop";
 
 function RegisterModal({ form }: any) {
   const shopId = "c90e94dd-556b-4fad-9bef-f6c81cc4f242";
   const noticeId = "1";
+  const noticeRegistrationMutation = useNoticeRegistration();
 
-  return (
-    <AlertDialog>
-      <AlertDialogTrigger asChild>
-        <Button
-          type="submit"
-          disabled={!form.formState.isValid}
-          className="flex h-[4.8rem] items-center justify-center gap-[0.8rem] self-stretch rounded-md bg-primary px-[13.6rem] py-[1.4rem]"
-        >
-          <span className="text-center text-[1.6rem] font-bold leading-5 text-white">
-            등록하기
-          </span>
-        </Button>
-      </AlertDialogTrigger>
+  if (noticeRegistrationMutation.isSuccess) {
+    return (
       <AlertDialogContent className="flex h-[22rem] w-[32.7rem] flex-col items-center justify-center gap-[5rem] rounded-md border border-none bg-white py-[2.8rem]">
         <AlertDialogHeader>
           <AlertDialogTitle className="text-[1.6rem] font-medium not-italic leading-normal text-[#333236]">
@@ -44,6 +35,22 @@ function RegisterModal({ form }: any) {
           </Link>
         </AlertDialogFooter>
       </AlertDialogContent>
+    );
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          type="submit"
+          disabled={!form.formState.isValid}
+          className="flex h-[4.8rem] items-center justify-center gap-[0.8rem] self-stretch rounded-md bg-primary px-[13.6rem] py-[1.4rem]"
+        >
+          <span className="text-center text-[1.6rem] font-bold leading-5 text-white">
+            등록하기
+          </span>
+        </Button>
+      </AlertDialogTrigger>
     </AlertDialog>
   );
 }

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -7,4 +7,7 @@ export const errorMessage = {
   REQUIRED_PASSWORD: "비밀번호를 입력해 주세요.",
   MIN_LENGTH_PASSWORD: `${PASSWORD_MIN_LENGTH}자 이상 입력해 주세요.`,
   NOT_EQUAL_PASSWORD_CONFIRM: "비밀번호가 일치하지 않습니다.",
+  REQUIRED_HOURLYPAY: "시급을 입력해 주세요.",
+  REQUIRED_STARTSAT: "시작 일시를 입력해 주세요.",
+  REQUIRED_WORKHOUR: "업무 시간을 입력해 주세요.",
 };

--- a/src/hooks/useNoticeRegistForm.ts
+++ b/src/hooks/useNoticeRegistForm.ts
@@ -1,6 +1,8 @@
 import { SubmitHandler, useForm } from "react-hook-form";
 
+import { errorMessage } from "@/helpers/validation";
 import { useNoticeRegistration } from "@/queries/shop";
+import { FormRules } from "@/types/form";
 import { NoticeRegistFormField } from "@/types/shop";
 
 export default function useSignupForm() {
@@ -23,5 +25,58 @@ export default function useSignupForm() {
     });
   };
 
-  return { form, onSubmit };
+  const rules: FormRules<NoticeRegistFormField> = {
+    hourlyPay: {
+      validate: (value) => {
+        if (value === undefined || value === null || value === "") {
+          return errorMessage.REQUIRED_HOURLYPAY;
+        }
+        const parsedValue =
+          typeof value === "string" ? parseFloat(value) : value;
+        if (parsedValue === 0) {
+          return errorMessage.REQUIRED_HOURLYPAY;
+        }
+        return true;
+      },
+    },
+    startsAt: {
+      required: {
+        value: true,
+        message: errorMessage.REQUIRED_STARTSAT,
+      },
+    },
+    workhour: {
+      validate: (value) => {
+        if (value === undefined || value === null || value === "") {
+          return errorMessage.REQUIRED_WORKHOUR;
+        }
+        const parsedValue =
+          typeof value === "string" ? parseFloat(value) : value;
+        if (parsedValue === 0) {
+          return errorMessage.REQUIRED_WORKHOUR;
+        }
+        return true;
+      },
+    },
+  };
+
+  const handlers = {
+    hourlyPay: {
+      onBlur: () => {
+        form.trigger("hourlyPay");
+      },
+    },
+    startsAt: {
+      onBlur: () => {
+        form.trigger("startsAt");
+      },
+    },
+    workhour: {
+      onBlur: () => {
+        form.trigger("workhour");
+      },
+    },
+  };
+
+  return { form, onSubmit, rules, handlers };
 }

--- a/src/pages/shops/[shopId]/notices/register/index.tsx
+++ b/src/pages/shops/[shopId]/notices/register/index.tsx
@@ -9,12 +9,13 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import useNoticeRegistForm from "@/hooks/useNoticeRegistForm";
 
 function NoticeRegister() {
-  const { form, onSubmit } = useNoticeRegistForm();
+  const { form, onSubmit, rules, handlers } = useNoticeRegistForm();
 
   return (
     <>
@@ -57,6 +58,7 @@ function NoticeRegister() {
                         <FormField
                           control={form.control}
                           name="hourlyPay"
+                          rules={rules.hourlyPay}
                           render={({ field }) => (
                             <FormItem className="w-full">
                               <FormLabel
@@ -71,12 +73,14 @@ function NoticeRegister() {
                                     {...field}
                                     id="hourlyPay"
                                     name="hourlyPay"
+                                    onBlur={handlers.hourlyPay.onBlur}
                                   />
                                 </FormControl>
                                 <span className="absolute inset-y-0 right-0 flex items-center pr-[2rem] text-[1.6rem] font-normal not-italic leading-[2.6rem] text-black">
                                   원
                                 </span>
                               </div>
+                              <FormMessage className="absolute text-[1.2rem]" />
                             </FormItem>
                           )}
                         />
@@ -85,6 +89,7 @@ function NoticeRegister() {
                         <FormField
                           control={form.control}
                           name="startsAt"
+                          rules={rules.startsAt}
                           render={({ field }) => (
                             <FormItem className="w-full">
                               <FormLabel
@@ -99,9 +104,12 @@ function NoticeRegister() {
                                     {...field}
                                     id="startsAt"
                                     name="startsAt"
+                                    placeholder="2023-07-01 15:00"
+                                    onBlur={handlers.startsAt.onBlur}
                                   />
                                 </FormControl>
                               </div>
+                              <FormMessage className="absolute text-[1.2rem]" />
                             </FormItem>
                           )}
                         />
@@ -110,6 +118,7 @@ function NoticeRegister() {
                         <FormField
                           control={form.control}
                           name="workhour"
+                          rules={rules.workhour}
                           render={({ field }) => (
                             <FormItem className="w-full">
                               <FormLabel
@@ -124,12 +133,14 @@ function NoticeRegister() {
                                     {...field}
                                     id="workhour"
                                     name="workhour"
+                                    onBlur={handlers.workhour.onBlur}
                                   />
                                 </FormControl>
                                 <span className="absolute inset-y-0 right-0 flex items-center pr-[2rem] text-[1.6rem] font-normal not-italic leading-[2.6rem] text-black">
                                   시간
                                 </span>
                               </div>
+                              <FormMessage className="absolute text-[1.2rem]" />
                             </FormItem>
                           )}
                         />
@@ -160,7 +171,7 @@ function NoticeRegister() {
                         />
                       </div>
                     </div>
-                    <RegisterModal />
+                    <RegisterModal form={form} />
                   </div>
                 </div>
               </div>

--- a/src/queries/shop.ts
+++ b/src/queries/shop.ts
@@ -12,14 +12,8 @@ export const useNoticeRegistration = () => {
       description,
     }: NoticeRegistrationRequestBody) =>
       postNoticeRegistration({ hourlyPay, startsAt, workhour, description }),
-    onSuccess: () => {
-      alert("공고 등록이 완료되었습니다.");
-    },
+    onSuccess: () => {},
   });
 
   return mutation;
 };
-
-// const mapUserDtoToUser = (dto: NoticeRegistrationDTO): NoticeRegistFormField => ({
-//   id: dto.id,
-// });

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -12,6 +12,5 @@ export const apiRouteUtils = {
   SHOPS: "shops",
   TOKEN: "token",
   IMAGES: "images",
-  parseNoticeRegisterURL: (shopId: string) =>
-    `shops/${shopId}/notices/register`,
+  parseNoticeRegisterURL: (shopId: string) => `shops/${shopId}/notices`,
 };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,8 +4,6 @@ export const PAGE_ROUTES = {
   NOTICES: "/notices",
   SHOPS_REGISTER: "/shops/register",
   parseShopsURL: (shopId: string) => `/shops/${shopId}`,
-  parseNoticeRegisterURL: (shopId: string) =>
-    `/shops/${shopId}/notices/register`,
 };
 
 export const API_ROUTE = process.env.NEXT_PUBLIC_API_ENDPOINT;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,6 +4,8 @@ export const PAGE_ROUTES = {
   NOTICES: "/notices",
   SHOPS_REGISTER: "/shops/register",
   parseShopsURL: (shopId: string) => `/shops/${shopId}`,
+  parseNoticeRegisterURL: (shopId: string) =>
+    `/shops/${shopId}/notices/register`,
 };
 
 export const API_ROUTE = process.env.NEXT_PUBLIC_API_ENDPOINT;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,6 +4,8 @@ export const PAGE_ROUTES = {
   NOTICES: "/notices",
   SHOPS_REGISTER: "/shops/register",
   parseShopsURL: (shopId: string) => `/shops/${shopId}`,
+  parseNoticeRegisterURL: (shopId: string) =>
+    `/shops/${shopId}/notices/register`,
 };
 
 export const API_ROUTE = process.env.NEXT_PUBLIC_API_ENDPOINT;
@@ -12,5 +14,6 @@ export const apiRouteUtils = {
   SHOPS: "shops",
   TOKEN: "token",
   IMAGES: "images",
-  parseNoticeRegisterURL: (shopId: string) => `shops/${shopId}/notices`,
+  parseShopNoticesURL: (shopId: string) => `shops/${shopId}/notices`,
+  parseShopsURL: (shopId: string) => `shops/${shopId}`,
 };


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: 공고 등록 페이지 input 값들 중 필수 입력값이 존재함. 이 값들을 입력하지 않으면 공고 등록을 할 수 없게 유효성 검사 함수와, 버튼의 비활성화를 설정함
- RegisterModal 컴포넌트에서는 useNoticeRegistration 훅을 사용하여 mutation 상태를 확인하고, 그에 따라 UI를 렌더링하도록 수정

# 어떤 변화가 생겼나요?

- 공고 등록 페이지에서 공고 등록을 할 시 필수 입력값들의 유효성 검사 함수 추가
- 공고 '등록하기' 버튼에 disabled 속성을 추가 
- 시작 일시 input의 입력 예시를 보여주기 위해 placeholder 추가
- RegisterModal 컴포넌트에서 mutation 상태가 성공일 땐 '등록완료' 모달창이 보이고, 실패했을 땐 input 입력창을 유지하도록 수정
- 
# 스크린샷(optional)
<img width="352" alt="무제 4" src="https://github.com/S2-P3-T5/Julge/assets/129366303/a8dc316c-bda4-45f7-9598-9f031e1aa7ba">
