### PR TITLE
사장님 (가게 정보 상세) 가게 공고 유무에 따른 공고 추가 / 공고 리스트 컴포넌트 구현

### DIFF
--- a/src/apis/shops/index.ts
+++ b/src/apis/shops/index.ts
@@ -6,7 +6,7 @@ import { apiRouteUtils } from "@/routes";
 // TODO: 에러처리
 export const postImages = async (token: string, name: string) => {
   try {
-    const response = await fetcher.post(apiRouteUtils.IMAGES, {
+    const res = await fetcher.post(apiRouteUtils.IMAGES, {
       json: {
         name,
       },
@@ -14,7 +14,7 @@ export const postImages = async (token: string, name: string) => {
         Authorization: `Bearer ${token}`,
       },
     });
-    const result: any = await response.json();
+    const result: any = await res.json();
     return result.item.url;
   } catch (e: any) {}
 };
@@ -27,10 +27,20 @@ export const putPresignedURL = async (presignedURL: string, img: File) => {
 // TODO: 에러처리
 export const getShopsData = async (shopId: string) => {
   try {
-    const response = await fetcher.get(apiRouteUtils.parseShopsURL(shopId));
-    const result = await response.json();
+    const res = await fetcher.get(apiRouteUtils.parseShopsURL(shopId));
+    const result = await res.json();
     return result;
   } catch (e: any) {
     throw e;
   }
+};
+
+// TODO: 에러처리
+
+export const getNoticesListData = async (shopId: string) => {
+  try {
+    const res = await fetcher.get(apiRouteUtils.parseShopNoticesURL(shopId));
+    const result = await res.json();
+    return result;
+  } catch {}
 };

--- a/src/components/shop/EmptyDataCard.tsx
+++ b/src/components/shop/EmptyDataCard.tsx
@@ -1,20 +1,30 @@
 import Link from "next/link";
 
-import { PAGE_ROUTES } from "@/routes";
+interface EmptyDataCardProps {
+  title: string;
+  description: string;
+  buttonText: string;
+  buttonLink: string;
+}
 
-export default function EmptyShopCard() {
+export default function EmptyDataCard({
+  title,
+  description,
+  buttonText,
+  buttonLink,
+}: EmptyDataCardProps) {
   return (
     <div className="mx-auto flex w-[35.1rem] flex-col  gap-[1.6rem]  py-[4rem]">
-      <span className="text-[2rem] font-bold text-black">내 가게</span>
+      <span className="text-[2rem] font-bold text-black">{title}</span>
       <div className="flex  flex-col items-center justify-center gap-[1.6rem] rounded-[12px] border-[1px] border-gray-20 px-[2.4rem] py-[6rem]">
         <span className=" text-[1.4rem]  font-normal leading-[2.2rem]">
-          내 가게를 소개하고 공고도 등록해 보세요.
+          {description}
         </span>
         <Link
           className="inlineblock h-[3.7rem] w-[12.1rem] rounded-[6px] bg-primary px-[2rem] py-[1rem] text-center text-[1.4rem] font-bold leading-normal text-white"
-          href={PAGE_ROUTES.SHOPS_REGISTER}
+          href={buttonLink}
         >
-          가게 등록하기
+          {buttonText}
         </Link>
       </div>
     </div>

--- a/src/components/shop/ShopsNoticesList.tsx
+++ b/src/components/shop/ShopsNoticesList.tsx
@@ -1,0 +1,44 @@
+import ShopsNoticesListItem from "@/components/shop/ShopsNoticesListItem";
+
+interface ShopsNoticesListProps {
+  noticesListData: {
+    items: Array<{
+      item?: {
+        id: string;
+        hourlyPay: number;
+        startsAt: string;
+        workhour: number;
+        description: string;
+        closed: boolean;
+      };
+    }>;
+  };
+  shopData: {
+    id: string;
+    name: string;
+    category: string;
+    address1: string;
+    address2: string;
+    description: string;
+    imageUrl: string;
+    originalHourlyPay: number;
+  };
+}
+
+// TODO : any 타입 변경 필요
+export default function ShopsNoticesList({
+  noticesListData,
+  shopData,
+}: ShopsNoticesListProps) {
+  return (
+    <div>
+      {noticesListData.items.map((item: any) => (
+        <ShopsNoticesListItem
+          key={item.id}
+          item={item.item}
+          shopData={shopData}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/shop/ShopsNoticesListItem.tsx
+++ b/src/components/shop/ShopsNoticesListItem.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 
+import ArrowUpIconCustom from "@/components/ui/ArrowUpIconCustom";
 import {
   Card,
   CardContent,
@@ -33,6 +34,19 @@ const colorCalculate = (num: number) => {
   else return "red-10";
 };
 
+const timeCalculate = (time: string, workhour: number) => {
+  const startDay = time.split("T")[0];
+  const startTime = time.split("T")[1].split(":")[0];
+  const minute = time.split("T")[1].split(":")[1];
+  const endTimeCal =
+    +startTime + +workhour >= 24
+      ? +startTime + +workhour - 24
+      : +startTime + +workhour;
+  const endTime = 10 > endTimeCal ? "0" + endTimeCal : endTimeCal;
+
+  return [startDay, startTime, minute, endTime];
+};
+
 export default function ShopsNoticesListItem({
   item,
   shopData,
@@ -40,14 +54,10 @@ export default function ShopsNoticesListItem({
   const riseRate = Math.floor(
     (item.hourlyPay / shopData.originalHourlyPay - 1) * 100,
   );
-  const startDay = item.startsAt.split("T")[0];
-  const startTime = item.startsAt.split("T")[1].split(":")[0];
-  const minute = item.startsAt.split("T")[1].split(":")[1];
-  const endTimeCal =
-    +startTime + +item.workhour >= 24
-      ? +startTime + +item.workhour - 24
-      : +startTime + +item.workhour;
-  const endTime = 10 > endTimeCal ? "0" + endTimeCal : endTimeCal;
+  const [startDay, startTime, minute, endTime] = timeCalculate(
+    item.startsAt,
+    item.workhour,
+  );
   const color = colorCalculate(riseRate);
 
   return (
@@ -84,15 +94,7 @@ export default function ShopsNoticesListItem({
               <span className={`text-[1.2rem] font-[400] text-${color}`}>
                 기존 시급보다 {riseRate}%
               </span>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="16"
-                height="17"
-                viewBox="0 0 16 17"
-                className={`fill-${color}`}
-              >
-                <path d="M10.0001 13.5483H6.0001V8.21495H2.77344L8.0001 2.98828L13.2268 8.21495H10.0001V13.5483Z" />
-              </svg>
+              <ArrowUpIconCustom color={color} />
             </div>
           </div>
         </CardFooter>

--- a/src/components/shop/ShopsNoticesListItem.tsx
+++ b/src/components/shop/ShopsNoticesListItem.tsx
@@ -1,0 +1,102 @@
+import Image from "next/image";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface ShopsNoticesListItemProps {
+  shopData: {
+    name: string;
+    imageUrl: string;
+    address1: string;
+    originalHourlyPay: number;
+  };
+  item: {
+    id: string;
+    hourlyPay: number;
+    startsAt: string;
+    workhour: number;
+    description: string;
+    closed: boolean;
+  };
+}
+
+const colorCalculate = (num: number) => {
+  if (num >= 40) return "red-40";
+  else if (num >= 30) return "red-30";
+  else if (num >= 20) return "red-20";
+  else return "red-10";
+};
+
+export default function ShopsNoticesListItem({
+  item,
+  shopData,
+}: ShopsNoticesListItemProps) {
+  const riseRate = Math.floor(
+    (item.hourlyPay / shopData.originalHourlyPay - 1) * 100,
+  );
+  const startDay = item.startsAt.split("T")[0];
+  const startTime = item.startsAt.split("T")[1].split(":")[0];
+  const minute = item.startsAt.split("T")[1].split(":")[1];
+  const endTimeCal =
+    +startTime + +item.workhour >= 24
+      ? +startTime + +item.workhour - 24
+      : +startTime + +item.workhour;
+  const endTime = 10 > endTimeCal ? "0" + endTimeCal : endTimeCal;
+  const color = colorCalculate(riseRate);
+
+  return (
+    <>
+      <Card className="w-auto max-w-[37.5rem]">
+        <CardHeader>
+          <Image src={shopData.imageUrl} alt="" width={162} height={148} />
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-[1rem]">
+            <CardTitle>{shopData.name}</CardTitle>
+            <div className="flex items-start gap-[0.5rem]">
+              <Image src="/icons/clock.svg" alt="" width={16} height={16} />
+              <div>
+                <CardDescription>{startDay}</CardDescription>
+                <CardDescription>
+                  {startTime}:{minute}~{endTime}:{minute}({item.workhour}
+                  시간)
+                </CardDescription>
+              </div>
+            </div>
+            <div className="flex items-center gap-[0.5rem]">
+              <Image src="/icons/point.svg" alt="" width={16} height={16} />
+              <CardDescription>{shopData.address1}</CardDescription>
+            </div>
+          </div>
+        </CardContent>
+        <CardFooter>
+          <div className="flex flex-col">
+            <span className="text-[1.8rem] font-[700] text-black">
+              {item.hourlyPay}원
+            </span>
+            <div className="flex">
+              <span className={`text-[1.2rem] font-[400] text-${color}`}>
+                기존 시급보다 {riseRate}%
+              </span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="17"
+                viewBox="0 0 16 17"
+                className={`fill-${color}`}
+              >
+                <path d="M10.0001 13.5483H6.0001V8.21495H2.77344L8.0001 2.98828L13.2268 8.21495H10.0001V13.5483Z" />
+              </svg>
+            </div>
+          </div>
+        </CardFooter>
+      </Card>
+    </>
+  );
+}

--- a/src/components/ui/ArrowUpIconCustom.tsx
+++ b/src/components/ui/ArrowUpIconCustom.tsx
@@ -1,0 +1,13 @@
+export default function ArrowUpIconCustom({ color = "white" }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="17"
+      viewBox="0 0 16 17"
+      className={`fill-${color}`}
+    >
+      <path d="M10.0001 13.5483H6.0001V8.21495H2.77344L8.0001 2.98828L13.2268 8.21495H10.0001V13.5483Z" />
+    </svg>
+  );
+}

--- a/src/pages/shops/[shopId]/index.tsx
+++ b/src/pages/shops/[shopId]/index.tsx
@@ -2,8 +2,9 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 import { getShopsData } from "@/apis/shops";
-import EmptyShopCard from "@/components/shop/EmptyShopCard";
+import EmptyDataCard from "@/components/shop/EmptyDataCard";
 import ShopDataCard from "@/components/shop/ShopDataCard";
+import { PAGE_ROUTES } from "@/routes";
 
 type dataType = {
   id: "string";
@@ -52,9 +53,23 @@ export default function Shop() {
   ) : shopData ? (
     <div>
       <ShopDataCard shopId={shopId} shopData={shopData} />
-      {hasNotice ? <div>공고 리스트</div> : <div>공고 등록하기 카드</div>}
+      {hasNotice ? (
+        <div>공고 리스트</div>
+      ) : (
+        <EmptyDataCard
+          title="등록한 공고"
+          description="공고를 등록해 보세요."
+          buttonText="공고 등록하기"
+          buttonLink={PAGE_ROUTES.parseNoticeRegisterURL(shopId as string)}
+        />
+      )}
     </div>
   ) : (
-    <EmptyShopCard />
+    <EmptyDataCard
+      title="내 가게"
+      description="내 가게를 소개하고 공고도 등록해 보세요."
+      buttonText="가게 등록하기"
+      buttonLink={PAGE_ROUTES.SHOPS_REGISTER}
+    />
   );
 }

--- a/src/pages/shops/[shopId]/index.tsx
+++ b/src/pages/shops/[shopId]/index.tsx
@@ -1,38 +1,54 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
-import { getShopsData } from "@/apis/shops";
+import { getNoticesListData, getShopsData } from "@/apis/shops";
 import EmptyDataCard from "@/components/shop/EmptyDataCard";
 import ShopDataCard from "@/components/shop/ShopDataCard";
+import ShopsNoticesList from "@/components/shop/ShopsNoticesList";
 import { PAGE_ROUTES } from "@/routes";
 
-type dataType = {
-  id: "string";
-  name: "string";
-  category: "string";
-  address1: "string";
-  address2: "string";
-  description: "string";
-  imageUrl: "string";
-  originalHourlyPay: "number";
+type DataType = {
+  id: string;
+  name: string;
+  category: string;
+  address1: string;
+  address2: string;
+  description: string;
+  imageUrl: string;
+  originalHourlyPay: number;
   user: {
     item: {
-      id: "string";
-      email: "string";
-      type: "employer | employee";
-      name?: "string";
-      phone?: "string";
-      address?: "string";
-      bio?: "string";
+      id: string;
+      email: string;
+      type: "employer" | "employee";
+      name?: string;
+      phone?: string;
+      address?: string;
+      bio?: string;
     };
-    href: "string";
+    href: string;
   };
+};
+
+type NoticesType = {
+  items: Array<{
+    item?: {
+      id: string;
+      hourlyPay: number;
+      startsAt: string;
+      workhour: number;
+      description: string;
+      closed: boolean;
+    };
+  }>;
 };
 
 export default function Shop() {
   const [isLoading, setIsLoading] = useState(true);
-  const [shopData, setShopData] = useState<dataType | null>(null);
-  const hasNotice = false; //기능 구현 전 임시 설정
+  const [shopData, setShopData] = useState<DataType | null>(null);
+  const [noticesListData, setNoticesListData] = useState<NoticesType | null>(
+    null,
+  );
   const router = useRouter();
   const { shopId } = router.query;
 
@@ -40,8 +56,10 @@ export default function Shop() {
     if (typeof shopId === "string") {
       (async () => {
         // TODO : result type 재설정
-        const result: any = await getShopsData(shopId);
-        setShopData(result.item);
+        const shopDataApiResult: any = await getShopsData(shopId);
+        setShopData(shopDataApiResult.item);
+        const noticesListApiResult: any = await getNoticesListData(shopId);
+        setNoticesListData(noticesListApiResult);
         setIsLoading(false);
       })();
     }
@@ -53,8 +71,11 @@ export default function Shop() {
   ) : shopData ? (
     <div>
       <ShopDataCard shopId={shopId} shopData={shopData} />
-      {hasNotice ? (
-        <div>공고 리스트</div>
+      {noticesListData?.items.length ? (
+        <ShopsNoticesList
+          shopData={shopData}
+          noticesListData={noticesListData}
+        />
       ) : (
         <EmptyDataCard
           title="등록한 공고"


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #82
- 사장님 가게 정보 상세 페이지에서 공고 유무에 따라 공고 등록하기 또는 공고 목록이 보여야 한다.

# 어떤 변화가 생겼나요?
- 공고 없을 시 - 공고 등록 바로가기 카드 표시(
  - 기존 EmptyShopCard 에서 EmptyDataCard로 변경 후 컴포넌트 재사용 
- 공고 있을 시 - 공고 목록 표시
- 무한스크롤 구현 예정

# 스크린샷(optional)
- 공고 없을 시
<img width="308" alt="prrr" src="https://github.com/S2-P3-T5/Julge/assets/144401634/f2b5c054-8029-422e-b848-857fd8602e7c">

- 공고 있을 시
<img width="146" alt="pr2" src="https://github.com/S2-P3-T5/Julge/assets/144401634/a175bddb-4236-4a95-93d1-e2c4e1aceccc">
