### PR TITLE
사장님 ( 가게 정보 상세) 내 가게 공고 목록 무한 스크롤 구현

### DIFF
--- a/src/apis/shops/index.ts
+++ b/src/apis/shops/index.ts
@@ -44,3 +44,17 @@ export const getNoticesListData = async (shopId: string) => {
     return result;
   } catch {}
 };
+
+export const getNewNoticesListData = async (
+  shopId: string,
+  offset: number,
+  limit: number,
+) => {
+  try {
+    const res = await fetcher.get(
+      apiRouteUtils.parseShopNewNoticesURL(shopId, offset, limit),
+    );
+    const result = await res.json();
+    return result;
+  } catch {}
+};

--- a/src/apis/shops/index.ts
+++ b/src/apis/shops/index.ts
@@ -45,14 +45,18 @@ export const getNoticesListData = async (shopId: string) => {
   } catch {}
 };
 
+type OptionsType = {
+  offset: number;
+  limit: number;
+};
+
 export const getNewNoticesListData = async (
   shopId: string,
-  offset: number,
-  limit: number,
+  options: OptionsType,
 ) => {
   try {
     const res = await fetcher.get(
-      apiRouteUtils.parseShopNewNoticesURL(shopId, offset, limit),
+      apiRouteUtils.parseShopNewNoticesURL(shopId, options),
     );
     const result = await res.json();
     return result;

--- a/src/components/shop/ShopsNoticesList.tsx
+++ b/src/components/shop/ShopsNoticesList.tsx
@@ -52,11 +52,10 @@ export default function ShopsNoticesList({
   const fetchMoreItems = async () => {
     if (newNoticesListData.hasNext) {
       const nextPage = newNoticesListData.offset + newNoticesListData.limit;
-      const newData: any = await getNewNoticesListData(
-        shopData.id,
-        nextPage,
-        newNoticesListData.limit,
-      );
+      const newData: any = await getNewNoticesListData(shopData.id, {
+        offset: nextPage,
+        limit: newNoticesListData.limit,
+      });
       setNewNoticesListData(newData);
       const items = newNoticesListData.items.concat(newData.items);
       setitemList(items);

--- a/src/components/shop/ShopsNoticesList.tsx
+++ b/src/components/shop/ShopsNoticesList.tsx
@@ -1,7 +1,14 @@
+import { useEffect, useState } from "react";
+
+import { getNewNoticesListData } from "@/apis/shops";
 import ShopsNoticesListItem from "@/components/shop/ShopsNoticesListItem";
 
 interface ShopsNoticesListProps {
   noticesListData: {
+    offset: number;
+    limit: number;
+    count: number;
+    hasNext: boolean;
     items: Array<{
       item?: {
         id: string;
@@ -30,15 +37,48 @@ export default function ShopsNoticesList({
   noticesListData,
   shopData,
 }: ShopsNoticesListProps) {
+  const [newNoticesListData, setNewNoticesListData] = useState(noticesListData);
+  const [itemList, setitemList] = useState(newNoticesListData.items);
+
+  const handleScroll = () => {
+    if (
+      window.innerHeight + document.documentElement.scrollTop ===
+      document.documentElement.offsetHeight
+    ) {
+      fetchMoreItems();
+    }
+  };
+
+  const fetchMoreItems = async () => {
+    if (newNoticesListData.hasNext) {
+      const nextPage = newNoticesListData.offset + newNoticesListData.limit;
+      const newData: any = await getNewNoticesListData(
+        shopData.id,
+        nextPage,
+        newNoticesListData.limit,
+      );
+      setNewNoticesListData(newData);
+      const items = newNoticesListData.items.concat(newData.items);
+      setitemList(items);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
   return (
     <div>
-      {noticesListData.items.map((item: any) => (
-        <ShopsNoticesListItem
-          key={item.id}
-          item={item.item}
-          shopData={shopData}
-        />
-      ))}
+      <ul>
+        {itemList.map((item: any) => (
+          <li key={item.item.id}>
+            <ShopsNoticesListItem item={item.item} shopData={shopData} />
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/pages/shops/[shopId]/index.tsx
+++ b/src/pages/shops/[shopId]/index.tsx
@@ -31,6 +31,10 @@ type DataType = {
 };
 
 type NoticesType = {
+  offset: number;
+  limit: number;
+  count: number; // 전체 개수
+  hasNext: boolean; // 다음 내용 존재 여부
   items: Array<{
     item?: {
       id: string;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -18,4 +18,6 @@ export const apiRouteUtils = {
   parseShopsURL: (shopId: string) => `shops/${shopId}`,
   parseShopNoticeDetail: (shopId: string, noticeId: string) =>
     `shops/${shopId}/notices/${noticeId}`,
+  parseShopNewNoticesURL: (shopId: string, offset: number, limit: number) =>
+    `shops/${shopId}/notices?offset=${offset}&limit=${limit}`,
 };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -18,6 +18,11 @@ export const apiRouteUtils = {
   parseShopsURL: (shopId: string) => `shops/${shopId}`,
   parseShopNoticeDetail: (shopId: string, noticeId: string) =>
     `shops/${shopId}/notices/${noticeId}`,
-  parseShopNewNoticesURL: (shopId: string, offset: number, limit: number) =>
-    `shops/${shopId}/notices?offset=${offset}&limit=${limit}`,
+  parseShopNewNoticesURL: (shopId: string, options: OptionsType) =>
+    `shops/${shopId}/notices?offset=${options.offset}&limit=${options.limit}`,
+};
+
+type OptionsType = {
+  offset: number;
+  limit: number;
 };


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #93 
- 현재 내 가게 페이지에서 공고 목록을 한 번에 표시하면 페이지 로딩 시간이 길어질 수 있습니다.  스크롤을 마지막까지 내렸을 때 추가로 공고를 불러와 보다 빠르게 페이지를 로딩하고 표시할 수 있습니다.

# 어떤 변화가 생겼나요?
- 공고목록을 10개 단위로 불러오고 스크롤을 내렸을 때 추가 로딩함

# 스크린샷(optional)
![pr5555](https://github.com/S2-P3-T5/Julge/assets/144401634/2218c026-3d46-4dd5-94c9-9cd28aa42d47)
