### PR TITLE
사장님(가게 정보 상세) 가게 정보 등록 / 편집 페이지에서 X버튼 뒤로가기 기능 구현

### DIFF
--- a/src/components/shop/ShopDataForm.tsx
+++ b/src/components/shop/ShopDataForm.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import Link from "next/link";
 
 import ShopImageCard from "@/components/shop/ShopImageCard";
@@ -10,6 +9,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { AlertDialog, AlertDialogTrigger } from "@/components/ui/alert-dialog";
+import BackPageButton from "@/components/ui/BackPageButton";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -90,7 +90,7 @@ export default function ShopDataForm({
     <>
       <div className="flex justify-between">
         <span>가게 정보</span>
-        <Image src="/icons/close.svg" width="10" height="10" alt="종료이미지" />
+        <BackPageButton />
       </div>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">

--- a/src/components/ui/BackPageButton.tsx
+++ b/src/components/ui/BackPageButton.tsx
@@ -9,7 +9,7 @@ export default function BackPageButton() {
 
   return (
     <div className="cursor-pointer" onClick={handleBackPage}>
-      <Image src="/icons/close.svg" width="24" height="24" alt="종료이미지" />
+      <Image src="/icons/close.svg" width="24" height="24" alt="" />
     </div>
   );
 }

--- a/src/components/ui/BackPageButton.tsx
+++ b/src/components/ui/BackPageButton.tsx
@@ -1,0 +1,15 @@
+import Image from "next/image";
+import { useRouter } from "next/router";
+
+export default function BackPageButton() {
+  const router = useRouter();
+  const handleBackPage = () => {
+    router.back();
+  };
+
+  return (
+    <div className="cursor-pointer" onClick={handleBackPage}>
+      <Image src="/icons/close.svg" width="24" height="24" alt="종료이미지" />
+    </div>
+  );
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,7 +1,6 @@
 export const PAGE_ROUTES = {
   SIGNUP: "/signup",
   SIGNIN: "/signin",
-  SHOPS: "/shops",
   NOTICES: "/notices",
   SHOPS_REGISTER: "/shops/register",
   SHOPS: "/shops",


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #104 
- 가게 정보 입력 / 수정 폼에서 작업 취소 후 뒤로 가기 동작 필요

# 어떤 변화가 생겼나요?
- 뒤로 가기 버튼 클릭 시, 이전페이지로 이동
- ui 폴더에 작성하여 필요 시 다른 컴포넌트에서 사용 가능

# 스크린샷(optional)
![뒤로가기 버튼](https://github.com/S2-P3-T5/Julge/assets/144401634/b1a0df1a-3826-481a-af92-c78fc9d26832)
