### PR TITLE
사장님 -( 공고 등록 페이지 ): 시작일시 input 값을 받아 양식에 맞게 수정해서 post 할 수 있도록 수정

### DIFF
--- a/src/hooks/useNoticeRegistForm.ts
+++ b/src/hooks/useNoticeRegistForm.ts
@@ -17,9 +17,11 @@ export default function useSignupForm() {
     workhour,
     description,
   }) => {
+    const formattedStartsAt = `${startsAt}:00Z`;
+
     mutate({
       hourlyPay,
-      startsAt,
+      startsAt: formattedStartsAt,
       workhour,
       description,
     });

--- a/src/pages/shops/[shopId]/notices/register/index.tsx
+++ b/src/pages/shops/[shopId]/notices/register/index.tsx
@@ -104,7 +104,7 @@ function NoticeRegister() {
                                     {...field}
                                     id="startsAt"
                                     name="startsAt"
-                                    placeholder="2023-07-01 15:00"
+                                    type="datetime-local"
                                     onBlur={handlers.startsAt.onBlur}
                                   />
                                 </FormControl>
@@ -114,6 +114,7 @@ function NoticeRegister() {
                           )}
                         />
                       </div>
+
                       <div className="flex w-full flex-col items-start gap-[0.8rem]">
                         <FormField
                           control={form.control}


### PR DESCRIPTION
…입력값을 변경하는 기능 구현

# 왜 필요한가요?

- 관련 이슈: 시작일시 input 값이 RFC 3339 포맷이 아니거나, 과거 날짜일 경우 submit을 할 수 없기에 input 값을 post하기 전 수정해야 했음

# 어떤 변화가 생겼나요?

- startAt이라는 이름의 input에서 출력하는 값을 수정하여 :00Z를 추가한 값을 submit하기 위해서 onSubmit 함수 내에서 해당 값을 수정하고, startAt 값을 원하는 형식으로 수정한 후에 mutate 함수를 호출함

# 스크린샷(optional)
![image](https://github.com/S2-P3-T5/Julge/assets/129366303/90680e41-a7af-4453-89f2-04280162271d)
