### PR TITLE
사장님 - 내 가게 / 공고 정보 없을 시 표시되는 EmptyDataCard 컴포넌트 디자인 / 반응형 구현

### DIFF
--- a/src/components/shop/EmptyDataCard.tsx
+++ b/src/components/shop/EmptyDataCard.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { Button } from "@/components/ui/button";
+
 interface EmptyDataCardProps {
   title: string;
   description: string;
@@ -14,18 +16,22 @@ export default function EmptyDataCard({
   buttonLink,
 }: EmptyDataCardProps) {
   return (
-    <div className="mx-auto flex w-[35.1rem] flex-col  gap-[1.6rem]  py-[4rem]">
-      <span className="text-[2rem] font-bold text-black">{title}</span>
-      <div className="flex  flex-col items-center justify-center gap-[1.6rem] rounded-[12px] border-[1px] border-gray-20 px-[2.4rem] py-[6rem]">
-        <span className=" text-[1.4rem]  font-normal leading-[2.2rem]">
+    <div className="mx-auto flex w-[35.1rem] flex-col items-center gap-[1.6rem] py-[4rem] tablet:my-[6rem] tablet:w-[68rem] tablet:gap-[2.4rem] desktop:w-[96.5rem]">
+      <span className="w-[100%] text-[2rem] font-bold text-black tablet:text-[2.8rem]">
+        {title}
+      </span>
+      <div className="flex w-[100%] flex-col items-center justify-center gap-[1.6rem] rounded-[12px] border-[1px] border-gray-20 px-[2.4rem] py-[6rem] tablet:gap-[2.4rem]">
+        <span className="text-center text-[1.4rem] font-normal leading-[2.2rem] text-black tablet:text-[1.6rem] tablet:leading-[2.6rem]">
           {description}
         </span>
-        <Link
-          className="inlineblock h-[3.7rem] w-[12.1rem] rounded-[6px] bg-primary px-[2rem] py-[1rem] text-center text-[1.4rem] font-bold leading-normal text-white"
-          href={buttonLink}
-        >
-          {buttonText}
-        </Link>
+        <Button asChild>
+          <Link
+            className="inlineblock max-content flex h-[3.7rem] w-[10.8rem] items-center rounded-[6px] bg-primary px-[2rem] py-[1rem] text-[14px] font-bold leading-normal text-white tablet:px-[13.6rem] tablet:py-[1.4rem] tablet:text-[1.6rem] tablet:leading-[2rem]"
+            href={buttonLink}
+          >
+            {buttonText}
+          </Link>
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #122 
- 가게 / 공고 정보 없을 시 표시되는 카드의 반응형과 세부 디자인이 필요

# 어떤 변화가 생겼나요?
- EmptyDataCard의 디자인과 반응형 구현

# 스크린샷(optional)
- 모바일
<img width="393" alt="모바일1" src="https://github.com/S2-P3-T5/Julge/assets/144401634/a635951a-620c-4b9f-8ab5-8060ac4cdc96">

- 태블릿
<img width="624" alt="태블릿1" src="https://github.com/S2-P3-T5/Julge/assets/144401634/e4a57842-fb4a-4fad-8503-d91cbe39a3cc">

- 데스크탑
<img width="845" alt="데스크탑1" src="https://github.com/S2-P3-T5/Julge/assets/144401634/a5fd7e3c-2e49-47c3-a1c7-e25c4adf0919">

