### PR TITLE
사장님 - 가게 정보 등록 / 편집 데이터 입력 form 디자인 / 반응형 구현

### DIFF
--- a/src/components/shop/ShopDataForm.tsx
+++ b/src/components/shop/ShopDataForm.tsx
@@ -147,7 +147,7 @@ export default function ShopDataForm({
                   >
                     <FormControl>
                       <SelectTrigger className="text-[1.6rem] leading-[2.6rem]">
-                        <SelectValue placeholder="입력" />
+                        <SelectValue placeholder="선택" />
                       </SelectTrigger>
                     </FormControl>
                     <FormMessage className="absolute bottom-[-2rem] text-[1.2rem]" />
@@ -184,7 +184,7 @@ export default function ShopDataForm({
                   >
                     <FormControl>
                       <SelectTrigger className="text-[1.6rem] leading-[2.6rem]">
-                        <SelectValue placeholder="입력" />
+                        <SelectValue placeholder="선택" />
                       </SelectTrigger>
                     </FormControl>
                     <FormMessage className="absolute bottom-[-2rem] text-[1.2rem]" />
@@ -247,14 +247,19 @@ export default function ShopDataForm({
                   <FormLabel className="text-[1.6rem] leading-[2.6rem] tablet:w-[33rem] desktop:w-[47.2rem]">
                     기본 시급*
                   </FormLabel>
-                  <FormControl>
-                    <Input
-                      className="text-[1.6rem] leading-[2.6rem]"
-                      placeholder="입력"
-                      {...field}
-                      onBlur={() => form.trigger("originalHourlyPay")}
-                    />
-                  </FormControl>
+                  <div className="relative">
+                    <FormControl>
+                      <Input
+                        className="text-[1.6rem] leading-[2.6rem]"
+                        placeholder="입력"
+                        {...field}
+                        onBlur={() => form.trigger("originalHourlyPay")}
+                      />
+                    </FormControl>
+                    <span className="absolute right-[2rem] top-[1.6rem] text-[1.6rem]">
+                      원
+                    </span>
+                  </div>
                   <FormMessage className="absolute bottom-[-2rem] text-[1.2rem]" />
                 </FormItem>
               )}

--- a/src/components/shop/ShopDataForm.tsx
+++ b/src/components/shop/ShopDataForm.tsx
@@ -91,14 +91,16 @@ export default function ShopDataForm({
   const NUM_REGEX = /^\d+$/;
 
   return (
-    <div className="mx-auto flex w-[35.1rem] flex-col gap-[2.4rem] pb-[8rem] pt-[4rem] tablet:py-[6rem]">
+    <div className="mx-auto flex w-[35.1rem] flex-col gap-[2.4rem] pb-[8rem] pt-[4rem] tablet:w-[68rem] tablet:gap-[3.2rem] tablet:py-[6rem] desktop:w-[96.4rem]">
       <div className="flex items-center justify-between">
-        <span className="text-[2rem] font-bold text-black">가게 정보</span>
+        <span className="text-[2rem] font-bold text-black tablet:text-[2.8rem]">
+          가게 정보
+        </span>
         <BackPageButton />
       </div>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-          <div className="flex flex-col gap-[2rem]">
+          <div className="flex flex-col gap-[2rem] tablet:flex-row tablet:flex-wrap tablet:justify-between tablet:gap-y-[2.4rem]">
             <FormField
               control={form.control}
               rules={{
@@ -115,7 +117,7 @@ export default function ShopDataForm({
                   </FormLabel>
                   <FormControl>
                     <Input
-                      className="text-[1.6rem] leading-[2.6rem]"
+                      className="text-[1.6rem] leading-[2.6rem] tablet:w-[33rem] desktop:w-[47.2rem]"
                       placeholder="입력"
                       {...field}
                       onBlur={() => form.trigger("name")}
@@ -136,7 +138,7 @@ export default function ShopDataForm({
               name="category"
               render={({ field }) => (
                 <FormItem className="relative flex flex-col">
-                  <FormLabel className="text-[1.6rem] leading-[2.6rem]">
+                  <FormLabel className="text-[1.6rem] leading-[2.6rem] tablet:w-[33rem] desktop:w-[47.2rem]">
                     분류*
                   </FormLabel>
                   <Select
@@ -173,7 +175,7 @@ export default function ShopDataForm({
               name="address1"
               render={({ field }) => (
                 <FormItem className="relative flex flex-col">
-                  <FormLabel className="text-[1.6rem] leading-[2.6rem]">
+                  <FormLabel className="text-[1.6rem] leading-[2.6rem] tablet:w-[33rem] desktop:w-[47.2rem]">
                     주소*
                   </FormLabel>
                   <Select
@@ -208,7 +210,7 @@ export default function ShopDataForm({
               name="address2"
               render={({ field }) => (
                 <FormItem className="relative flex flex-col">
-                  <FormLabel className="text-[1.6rem] leading-[2.6rem]">
+                  <FormLabel className="text-[1.6rem] leading-[2.6rem] tablet:w-[33rem] desktop:w-[47.2rem]">
                     상세 주소*
                   </FormLabel>
                   <FormControl>
@@ -242,7 +244,7 @@ export default function ShopDataForm({
               name="originalHourlyPay"
               render={({ field }) => (
                 <FormItem className="relative flex flex-col">
-                  <FormLabel className="text-[1.6rem] leading-[2.6rem]">
+                  <FormLabel className="text-[1.6rem] leading-[2.6rem] tablet:w-[33rem] desktop:w-[47.2rem]">
                     기본 시급*
                   </FormLabel>
                   <FormControl>
@@ -286,7 +288,7 @@ export default function ShopDataForm({
                   <FormControl>
                     <Textarea
                       placeholder="입력"
-                      className="h-[15.3rem] resize-none rounded-[0.5rem] px-[2rem] py-[1.6rem] text-[1.6rem] leading-[2.6rem]"
+                      className="h-[15.3rem] resize-none rounded-[0.5rem] px-[2rem] py-[1.6rem] text-[1.6rem] leading-[2.6rem] tablet:h-[15.3rem] tablet:w-[68rem] desktop:w-[96.4rem]"
                       {...field}
                     />
                   </FormControl>
@@ -297,7 +299,7 @@ export default function ShopDataForm({
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button
-                className="mt-[2.4rem] flex h-[4.8rem] w-[35.1rem] items-center justify-center px-[13.6rem] py-[1.4rem] text-[1.6rem] font-bold leading-[2rem]"
+                className="mt-[2.4rem] flex h-[4.8rem] w-[35.1rem] items-center justify-center px-[13.6rem] py-[1.4rem] text-[1.6rem] font-bold leading-[2rem] tablet:mx-auto tablet:mt-[3.2rem]"
                 disabled={!form.formState.isValid}
                 type="submit"
               >

--- a/src/components/shop/ShopDataForm.tsx
+++ b/src/components/shop/ShopDataForm.tsx
@@ -91,192 +91,216 @@ export default function ShopDataForm({
   const NUM_REGEX = /^\d+$/;
 
   return (
-    <>
-      <div className="flex justify-between">
-        <span>가게 정보</span>
+    <div className="mx-auto flex w-[35.1rem] flex-col gap-[2.4rem] pb-[8rem] pt-[4rem] tablet:py-[6rem]">
+      <div className="flex items-center justify-between">
+        <span className="text-[2rem] font-bold text-black">가게 정보</span>
         <BackPageButton />
       </div>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-          <FormField
-            control={form.control}
-            rules={{
-              required: {
-                value: true,
-                message: errorMessage.REQUIRED_SHOPNAME,
-              },
-            }}
-            name="name"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>가게 이름*</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="입력"
-                    {...field}
-                    onBlur={() => form.trigger("name")}
-                  />
-                </FormControl>
-                <FormMessage className="absolute text-[1.2rem]" />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            rules={{
-              required: {
-                value: true,
-                message: errorMessage.REQUIRED_SHOPCATEGORY,
-              },
-            }}
-            name="category"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>분류*</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
-                  defaultValue={field.value}
-                >
+          <div className="flex flex-col gap-[2rem]">
+            <FormField
+              control={form.control}
+              rules={{
+                required: {
+                  value: true,
+                  message: errorMessage.REQUIRED_SHOPNAME,
+                },
+              }}
+              name="name"
+              render={({ field }) => (
+                <FormItem className="relative flex flex-col">
+                  <FormLabel className="text-[1.6rem] leading-[2.6rem]">
+                    가게 이름*
+                  </FormLabel>
                   <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="입력" />
-                    </SelectTrigger>
+                    <Input
+                      className="text-[1.6rem] leading-[2.6rem]"
+                      placeholder="입력"
+                      {...field}
+                      onBlur={() => form.trigger("name")}
+                    />
                   </FormControl>
-                  <FormMessage className="absolute text-[1.2rem]" />
-                  <SelectContent>
-                    {CATEGORY.map((item) => {
-                      return (
+                  <FormMessage className="absolute bottom-[-2rem] text-[1.2rem]" />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              rules={{
+                required: {
+                  value: true,
+                  message: errorMessage.REQUIRED_SHOPCATEGORY,
+                },
+              }}
+              name="category"
+              render={({ field }) => (
+                <FormItem className="relative flex flex-col">
+                  <FormLabel className="text-[1.6rem] leading-[2.6rem]">
+                    분류*
+                  </FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="text-[1.6rem] leading-[2.6rem]">
+                        <SelectValue placeholder="입력" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <FormMessage className="absolute bottom-[-2rem] text-[1.2rem]" />
+                    <SelectContent>
+                      {CATEGORY.map((item) => {
+                        return (
+                          <SelectItem key={item} value={item}>
+                            {item}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              rules={{
+                required: {
+                  value: true,
+                  message: errorMessage.REQUIRED_ADDRESS,
+                },
+              }}
+              name="address1"
+              render={({ field }) => (
+                <FormItem className="relative flex flex-col">
+                  <FormLabel className="text-[1.6rem] leading-[2.6rem]">
+                    주소*
+                  </FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="text-[1.6rem] leading-[2.6rem]">
+                        <SelectValue placeholder="입력" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <FormMessage className="absolute bottom-[-2rem] text-[1.2rem]" />
+                    <SelectContent>
+                      {ADDRESS.map((item) => (
                         <SelectItem key={item} value={item}>
                           {item}
                         </SelectItem>
-                      );
-                    })}
-                  </SelectContent>
-                </Select>
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            rules={{
-              required: {
-                value: true,
-                message: errorMessage.REQUIRED_ADDRESS,
-              },
-            }}
-            name="address1"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>주소*</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
-                  defaultValue={field.value}
-                >
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              rules={{
+                required: {
+                  value: true,
+                  message: errorMessage.REQUIRED_DETAILED_ADDRESS,
+                },
+              }}
+              name="address2"
+              render={({ field }) => (
+                <FormItem className="relative flex flex-col">
+                  <FormLabel className="text-[1.6rem] leading-[2.6rem]">
+                    상세 주소*
+                  </FormLabel>
                   <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="입력" />
-                    </SelectTrigger>
+                    <Input
+                      className="text-[1.6rem] leading-[2.6rem]"
+                      placeholder="입력"
+                      {...field}
+                      onBlur={() => form.trigger("address2")}
+                    />
                   </FormControl>
-                  <FormMessage className="absolute text-[1.2rem]" />
-                  <SelectContent>
-                    {ADDRESS.map((item) => (
-                      <SelectItem key={item} value={item}>
-                        {item}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            rules={{
-              required: {
-                value: true,
-                message: errorMessage.REQUIRED_DETAILED_ADDRESS,
-              },
-            }}
-            name="address2"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>상세 주소*</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="입력"
-                    {...field}
-                    onBlur={() => form.trigger("address2")}
-                  />
-                </FormControl>
-                <FormMessage className="absolute text-[1.2rem]" />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            rules={{
-              required: {
-                value: true,
-                message: errorMessage.REQUIRED_HOURLYPAY,
-              },
-              pattern: {
-                value: NUM_REGEX,
-                message: errorMessage.REQUIRED_NUMBER,
-              },
-              min: {
-                value: 9860,
-                message: errorMessage.INVALID_HOURLYPAY,
-              },
-            }}
-            name="originalHourlyPay"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>기본 시급*</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="입력"
-                    {...field}
-                    onBlur={() => form.trigger("originalHourlyPay")}
-                  />
-                </FormControl>
-                <FormMessage className="absolute text-[1.2rem]" />
-              </FormItem>
-            )}
-          />
-          <FormItem>
-            <FormLabel htmlFor="imgSelector">
-              가게 이미지
-              <ShopImageCard imgURL={imgURL} />
-            </FormLabel>
-            <FormControl>
-              <Input
-                accept=".jpg, .jpeg, .png"
-                className="hidden"
-                id="imgSelector"
-                type="file"
-                onChange={handleInputImgFile}
-              />
-            </FormControl>
-          </FormItem>
-          <FormField
-            control={form.control}
-            name="description"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>가게 설명</FormLabel>
-                <FormControl>
-                  <Textarea
-                    placeholder="입력"
-                    className="resize-none"
-                    {...field}
-                  />
-                </FormControl>
-              </FormItem>
-            )}
-          />
+                  <FormMessage className="absolute bottom-[-2rem] text-[1.2rem]" />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              rules={{
+                required: {
+                  value: true,
+                  message: errorMessage.REQUIRED_HOURLYPAY,
+                },
+                pattern: {
+                  value: NUM_REGEX,
+                  message: errorMessage.REQUIRED_NUMBER,
+                },
+                min: {
+                  value: 9860,
+                  message: errorMessage.INVALID_HOURLYPAY,
+                },
+              }}
+              name="originalHourlyPay"
+              render={({ field }) => (
+                <FormItem className="relative flex flex-col">
+                  <FormLabel className="text-[1.6rem] leading-[2.6rem]">
+                    기본 시급*
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      className="text-[1.6rem] leading-[2.6rem]"
+                      placeholder="입력"
+                      {...field}
+                      onBlur={() => form.trigger("originalHourlyPay")}
+                    />
+                  </FormControl>
+                  <FormMessage className="absolute bottom-[-2rem] text-[1.2rem]" />
+                </FormItem>
+              )}
+            />
+            <FormItem className="relative flex flex-col">
+              <FormLabel
+                htmlFor="imgSelector"
+                className="text-[1.6rem] leading-[2.6rem]"
+              >
+                가게 이미지
+                <ShopImageCard imgURL={imgURL} />
+              </FormLabel>
+              <FormControl>
+                <Input
+                  accept=".jpg, .jpeg, .png"
+                  className="hidden"
+                  id="imgSelector"
+                  type="file"
+                  onChange={handleInputImgFile}
+                />
+              </FormControl>
+            </FormItem>
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem className="relative flex flex-col">
+                  <FormLabel className="text-[1.6rem] leading-[2.6rem]">
+                    가게 설명
+                  </FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="입력"
+                      className="h-[15.3rem] resize-none rounded-[0.5rem] px-[2rem] py-[1.6rem] text-[1.6rem] leading-[2.6rem]"
+                      {...field}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </div>
           <AlertDialog>
             <AlertDialogTrigger asChild>
-              <Button disabled={!form.formState.isValid} type="submit">
+              <Button
+                className="mt-[2.4rem] flex h-[4.8rem] w-[35.1rem] items-center justify-center px-[13.6rem] py-[1.4rem] text-[1.6rem] font-bold leading-[2rem]"
+                disabled={!form.formState.isValid}
+                type="submit"
+              >
                 {buttonText}
               </Button>
             </AlertDialogTrigger>
@@ -295,6 +319,6 @@ export default function ShopDataForm({
           </AlertDialog>
         </form>
       </Form>
-    </>
+    </div>
   );
 }

--- a/src/components/shop/ShopImageCard.tsx
+++ b/src/components/shop/ShopImageCard.tsx
@@ -6,13 +6,22 @@ interface ShopImageCardProps {
 export default function ShopImageCard({ imgURL }: ShopImageCardProps) {
   return (
     <>
-      <div className="flex h-[20rem] w-[35.1rem] flex-col items-center justify-center bg-gray-10">
+      <div className="mt-[0.8rem] flex h-[20rem] w-[35.1rem] flex-col items-center justify-center rounded-[1.2rem] bg-gray-10">
         {imgURL ? (
-          <Image src={imgURL} height="200" width="351" alt="미리보기 이미지" />
+          <div className="h-[20rem] w-[35.1rem] overflow-hidden">
+            <Image
+              src={imgURL}
+              height="200"
+              width="351"
+              alt="미리보기 이미지"
+            />
+          </div>
         ) : (
-          <div className="flex flex-col items-center justify-center gap-[11px]">
+          <div className="flex h-[20rem] w-[35.1rem] cursor-pointer flex-col items-center justify-center gap-[11px]">
             <Image src="/icons/camera.svg" width="32" height="32" alt="" />
-            <span>이미지 추가하기</span>
+            <span className="text-[1.6rem] font-bold leading-[2rem] text-gray-40">
+              이미지 추가하기
+            </span>
           </div>
         )}
       </div>

--- a/src/components/shop/ShopImageCard.tsx
+++ b/src/components/shop/ShopImageCard.tsx
@@ -6,9 +6,9 @@ interface ShopImageCardProps {
 export default function ShopImageCard({ imgURL }: ShopImageCardProps) {
   return (
     <>
-      <div className="mt-[0.8rem] flex h-[20rem] w-[35.1rem] flex-col items-center justify-center rounded-[1.2rem] bg-gray-10">
+      <div className="mt-[0.8rem] flex h-[20rem] w-[35.1rem] flex-col items-center justify-center rounded-[1.2rem] bg-gray-10 tablet:h-[27.6rem] tablet:w-[48.3rem]">
         {imgURL ? (
-          <div className="h-[20rem] w-[35.1rem] overflow-hidden">
+          <div className="h-[20rem] w-[35.1rem] overflow-hidden tablet:h-[27.6rem] tablet:w-[48.3rem]">
             <Image
               src={imgURL}
               height="200"
@@ -17,7 +17,7 @@ export default function ShopImageCard({ imgURL }: ShopImageCardProps) {
             />
           </div>
         ) : (
-          <div className="flex h-[20rem] w-[35.1rem] cursor-pointer flex-col items-center justify-center gap-[11px]">
+          <div className="flex h-[20rem] w-[35.1rem] cursor-pointer flex-col items-center justify-center gap-[11px] tablet:h-[27.6rem] tablet:w-[48.3rem]">
             <Image src="/icons/camera.svg" width="32" height="32" alt="" />
             <span className="text-[1.6rem] font-bold leading-[2rem] text-gray-40">
               이미지 추가하기

--- a/src/components/ui/BackPageButton.tsx
+++ b/src/components/ui/BackPageButton.tsx
@@ -9,7 +9,13 @@ export default function BackPageButton() {
 
   return (
     <div className="cursor-pointer" onClick={handleBackPage}>
-      <Image src="/icons/close.svg" width="24" height="24" alt="" />
+      <Image
+        className="tablet:h-[3.2rem] tablet:w-[3.2rem]"
+        src="/icons/close.svg"
+        width="24"
+        height="24"
+        alt=""
+      />
     </div>
   );
 }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -17,7 +17,8 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      (className =
+        "flex w-full items-center justify-between rounded-[0.6rem] border border-gray-30 bg-white px-[2rem] py-[1.6rem] text-[1.6rem] ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"),
       className,
     )}
     {...props}
@@ -116,7 +117,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm px-[2rem] py-[1.6rem] pl-8 pr-2 text-[1.6rem] outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #123 
- 사장님 가게정보 등록 /편집 페이지 세부 디지인과 반응형 구현 필요

# 어떤 변화가 생겼나요?
- 사장님 가게 정보 등록 / 편집 페이지 세부 디자인 및 반응형 구현
- 기본 시급 input '원' 표시 추가

# 스크린샷(optional)
- 모바일
<img width="340" alt="모" src="https://github.com/S2-P3-T5/Julge/assets/144401634/04fe606b-21af-4b2c-847e-f26bbf7d01ca">

- 태블릿
<img width="524" alt="태" src="https://github.com/S2-P3-T5/Julge/assets/144401634/d439ae01-2c78-4e74-a278-c7c242395be1">

- 데스크탑
<img width="630" alt="데" src="https://github.com/S2-P3-T5/Julge/assets/144401634/4a332f52-61e1-4cf3-9e95-502b83fc3622">

