### PR TITLE
사장님 : 가게 정보 상세 카드 컴포넌트 디자인 / 반응형 구현

### DIFF
--- a/src/components/shop/ShopDataCard.tsx
+++ b/src/components/shop/ShopDataCard.tsx
@@ -27,52 +27,65 @@ export default function ShopDataCard({ shopId, shopData }: ShopDataCardProps) {
   return (
     <>
       {typeof shopId === "string" && (
-        <div className="mx-auto flex w-[35.1rem] flex-col gap-[1.6rem] px-[1.2rem] py-[4rem]">
-          <span className="text-[2rem] font-bold">내 가게</span>
-          <Card className="flex w-[35.1rem] flex-col rounded-[0.8rem] border-none bg-red-10 p-[2rem]">
-            <div className="flex h-[17.8rem] w-[31.1rem] items-center overflow-hidden rounded-[1.2rem]">
+        <div className="mx-auto flex w-[35.1rem] flex-col gap-[1.6rem] px-[1.2rem] py-[4rem] tablet:mt-[6rem] tablet:w-[68rem] tablet:gap-[2.4rem] desktop:w-[96.4rem]">
+          <span className="text-[2rem] font-bold tablet:text-[2.8rem] desktop:text-[3.4rem]">
+            내 가게
+          </span>
+          <Card className="flex w-[35.1rem] flex-col rounded-[0.8rem] border-none bg-red-10 p-[2rem] tablet:w-[68rem] tablet:p-[2.4rem] desktop:w-[96.4rem] desktop:flex-row desktop:justify-between">
+            <div className="flex h-[17.8rem] w-[31.1rem] items-center overflow-hidden rounded-[1.2rem] tablet:h-[36rem] tablet:w-[63.2rem] desktop:h-[30.8rem] desktop:w-[53.9rem]">
               <Image
+                className="object-cover tablet:h-[36rem]  tablet:w-[63.2rem] desktop:h-[30.8rem] desktop:w-[53.9rem]"
                 src={shopData.imageUrl}
                 width="311"
                 height="178"
                 alt="가게이미지"
               />
             </div>
-            <div>
-              <CardHeader className="flex flex-col p-0 pt-[1.2rem]">
-                <div className="text-[1.4rem] font-bold text-primary">식당</div>
-                <CardTitle className="text-[2.4rem] font-bold">
-                  {shopData.name}
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="p-0">
-                <div className="flex gap-[0.6rem]">
-                  <Image src="/icons/point.svg" alt="" width={16} height={16} />
-                  <span className="leadning-[2.2rem] my-[0.8rem] block text-[1.4rem] text-gray-50">
-                    {shopData.address1}
-                  </span>
-                </div>
-                <p className="text-[1.4rem] leading-[2.2rem]">
-                  {shopData.description}
-                </p>
-              </CardContent>
-              <CardFooter className="mt-[2.4rem] flex justify-between gap-[10px] p-0">
+            <div className="desktop:flex desktop:flex-col desktop:justify-between">
+              <div>
+                <CardHeader className="flex flex-col p-0 pt-[1.2rem] tablet:pt-[1.6rem]">
+                  <div className="text-[1.4rem] font-bold text-primary tablet:text-[1.6rem]">
+                    식당
+                  </div>
+                  <CardTitle className="text-[2.4rem] font-bold tablet:text-[2.8rem]">
+                    {shopData.name}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="p-0">
+                  <div className="flex items-center gap-[0.6rem]">
+                    <Image
+                      className="tablet:h-[2rem] tablet:w-[2rem]"
+                      src="/icons/point.svg"
+                      alt=""
+                      width={16}
+                      height={16}
+                    />
+                    <span className="leadning-[2.2rem] my-[0.8rem] block text-[1.4rem] text-gray-50 tablet:my-[1.2rem] tablet:text-[1.6rem]">
+                      {shopData.address1}
+                    </span>
+                  </div>
+                  <p className="text-[1.4rem] leading-[2.2rem] tablet:text-[1.6rem]">
+                    {shopData.description}
+                  </p>
+                </CardContent>
+              </div>
+              <CardFooter className="mt-[2.4rem] flex justify-between gap-[10px] p-0 tablet:mt-[4rem]">
                 <Button asChild>
                   <Link
-                    className="h-[3.8rem] w-[15.1rem] rounded-[0.6rem] border-[1px] border-primary bg-white px-[2rem] py-[1rem]"
+                    className="h-[3.8rem] w-[15.1rem] rounded-[0.6rem] border-[1px] border-primary bg-white px-[2rem] py-[1rem] tablet:h-[4.8rem] tablet:w-[31.2rem] tablet:px-[13.6rem] tablet:py-[1.4rem] desktop:w-[16.9rem] desktop:px-0"
                     href={PAGE_ROUTES.parseShopsEditURL(shopId)}
                   >
-                    <span className="text-[1.4rem] font-bold text-primary">
+                    <span className="text-[1.4rem] font-bold text-primary tablet:text-[1.6rem] tablet:leading-[2rem]">
                       편집하기
                     </span>
                   </Link>
                 </Button>
                 <Button asChild>
                   <Link
-                    className="h-[3.8rem] w-[15.1rem] rounded-[0.6rem] px-[2rem] py-[1rem]"
+                    className="h-[3.8rem] w-[15.1rem] rounded-[0.6rem] px-[2rem] py-[1rem] tablet:h-[4.8rem]  tablet:w-[31.2rem] tablet:px-[13.6rem] tablet:py-[1.4rem] desktop:w-[16.9rem] desktop:px-0"
                     href={PAGE_ROUTES.parseNoticeRegisterURL(shopId)}
                   >
-                    <span className="text-[1.4rem] font-bold">
+                    <span className="text-[1.4rem] font-bold tablet:text-[1.6rem] tablet:leading-[2rem]">
                       공고 등록하기
                     </span>
                   </Link>

--- a/src/components/shop/ShopDataCard.tsx
+++ b/src/components/shop/ShopDataCard.tsx
@@ -27,32 +27,60 @@ export default function ShopDataCard({ shopId, shopData }: ShopDataCardProps) {
   return (
     <>
       {typeof shopId === "string" && (
-        <Card className="w-[350px] p-[20px]">
-          <Image
-            src={shopData.imageUrl}
-            width="311"
-            height="178"
-            alt="가게이미지"
-          />
-          <CardHeader>
-            <div>식당</div>
-            <CardTitle>{shopData.name}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <span>{shopData.address1}</span>
-            <p>{shopData.description}</p>
-          </CardContent>
-          <CardFooter className="flex gap-[10px]">
-            <Button asChild>
-              <Link href={PAGE_ROUTES.parseShopsEditURL(shopId)}>편집하기</Link>
-            </Button>
-            <Button asChild>
-              <Link href={PAGE_ROUTES.parseNoticeRegisterURL(shopId)}>
-                공고 등록하기
-              </Link>
-            </Button>
-          </CardFooter>
-        </Card>
+        <div className="mx-auto flex w-[35.1rem] flex-col gap-[1.6rem] px-[1.2rem] py-[4rem]">
+          <span className="text-[2rem] font-bold">내 가게</span>
+          <Card className="flex w-[35.1rem] flex-col rounded-[0.8rem] border-none bg-red-10 p-[2rem]">
+            <div className="flex h-[17.8rem] w-[31.1rem] items-center overflow-hidden rounded-[1.2rem]">
+              <Image
+                src={shopData.imageUrl}
+                width="311"
+                height="178"
+                alt="가게이미지"
+              />
+            </div>
+            <div>
+              <CardHeader className="flex flex-col p-0 pt-[1.2rem]">
+                <div className="text-[1.4rem] font-bold text-primary">식당</div>
+                <CardTitle className="text-[2.4rem] font-bold">
+                  {shopData.name}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="p-0">
+                <div className="flex gap-[0.6rem]">
+                  <Image src="/icons/point.svg" alt="" width={16} height={16} />
+                  <span className="leadning-[2.2rem] my-[0.8rem] block text-[1.4rem] text-gray-50">
+                    {shopData.address1}
+                  </span>
+                </div>
+                <p className="text-[1.4rem] leading-[2.2rem]">
+                  {shopData.description}
+                </p>
+              </CardContent>
+              <CardFooter className="mt-[2.4rem] flex justify-between gap-[10px] p-0">
+                <Button asChild>
+                  <Link
+                    className="h-[3.8rem] w-[15.1rem] rounded-[0.6rem] border-[1px] border-primary bg-white px-[2rem] py-[1rem]"
+                    href={PAGE_ROUTES.parseShopsEditURL(shopId)}
+                  >
+                    <span className="text-[1.4rem] font-bold text-primary">
+                      편집하기
+                    </span>
+                  </Link>
+                </Button>
+                <Button asChild>
+                  <Link
+                    className="h-[3.8rem] w-[15.1rem] rounded-[0.6rem] px-[2rem] py-[1rem]"
+                    href={PAGE_ROUTES.parseNoticeRegisterURL(shopId)}
+                  >
+                    <span className="text-[1.4rem] font-bold">
+                      공고 등록하기
+                    </span>
+                  </Link>
+                </Button>
+              </CardFooter>
+            </div>
+          </Card>
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #127 
- 사장님 가게 상세 페이지에서 가게 정보 세부 디자인과 반응형 디자인을 보여줘야 함

# 어떤 변화가 생겼나요?
- 가게 상세 정보 Card 컴포넌트 디자인과 반응형 구현

# 스크린샷(optional)
- 모바일
<img width="290" alt="스크린샷 2024-02-04 021134" src="https://github.com/S2-P3-T5/Julge/assets/144401634/dd664dd4-b1aa-4196-b0c5-8042b8daac3c">

- 태블릿
<img width="532" alt="스크린샷 2024-02-04 021143" src="https://github.com/S2-P3-T5/Julge/assets/144401634/b85f91de-5ad2-46be-87dd-ada2b7da3e9e">

- 데스크탑
<img width="837" alt="스크린샷 2024-02-04 021209" src="https://github.com/S2-P3-T5/Julge/assets/144401634/d2409a40-13c5-4917-b9e0-615e0b48655f">


