### PR TITLE
사장님 :가게 정보 상세 내 공고 리스트와 리스트 아이템 디자인 / 반응형 구현

### DIFF
--- a/src/components/shop/ShopsNoticesList.tsx
+++ b/src/components/shop/ShopsNoticesList.tsx
@@ -71,12 +71,15 @@ export default function ShopsNoticesList({
 
   return (
     <div>
-      <ul>
-        {itemList.map((item: any) => (
-          <li key={item.item.id}>
-            <ShopsNoticesListItem item={item.item} shopData={shopData} />
-          </li>
-        ))}
+      <ul className="flex flex-col gap-[1.6rem] px-[1.2rem] pb-[8rem] pt-[4rem]">
+        <span className="text-[2rem] font-bold">내가 등록한 공고</span>
+        <div className="flex w-[35.1rem] flex-wrap justify-between gap-x-[0.9rem] gap-y-[1.6rem]">
+          {itemList.map((item: any) => (
+            <li key={item.item.id}>
+              <ShopsNoticesListItem item={item.item} shopData={shopData} />
+            </li>
+          ))}
+        </div>
       </ul>
     </div>
   );

--- a/src/components/shop/ShopsNoticesList.tsx
+++ b/src/components/shop/ShopsNoticesList.tsx
@@ -71,9 +71,11 @@ export default function ShopsNoticesList({
 
   return (
     <div>
-      <ul className="flex flex-col gap-[1.6rem] px-[1.2rem] pb-[8rem] pt-[4rem]">
-        <span className="text-[2rem] font-bold">내가 등록한 공고</span>
-        <div className="flex w-[35.1rem] flex-wrap justify-between gap-x-[0.9rem] gap-y-[1.6rem]">
+      <ul className="mx-auto flex w-[35.1rem] flex-col gap-[1.6rem] pb-[8rem] pt-[4rem] tablet:w-[67.8rem] tablet:gap-[3.2rem] tablet:pb-[12rem] tablet:pt-[6rem] desktop:w-[96.4rem]">
+        <span className="text-[2rem] font-bold tablet:text-[2.8rem]">
+          내가 등록한 공고
+        </span>
+        <div className="flex w-[35.1rem] flex-wrap justify-between gap-x-[0.9rem] gap-y-[1.6rem] tablet:w-[67.8rem] tablet:gap-y-[3.2rem] desktop:w-[96.4rem]">
           {itemList.map((item: any) => (
             <li key={item.item.id}>
               <ShopsNoticesListItem item={item.item} shopData={shopData} />

--- a/src/components/shop/ShopsNoticesListItem.tsx
+++ b/src/components/shop/ShopsNoticesListItem.tsx
@@ -31,7 +31,7 @@ const colorCalculate = (num: number) => {
   if (num >= 40) return "red-40";
   else if (num >= 30) return "red-30";
   else if (num >= 20) return "red-20";
-  else if (num >= 10) return "red-10";
+  else return "red-10";
 };
 
 export const timeCalculate = (time: string, workhour: number) => {
@@ -62,10 +62,10 @@ export default function ShopsNoticesListItem({
 
   return (
     <div>
-      <Card className="w-[17.1rem] p-[1.2rem]">
-        <CardHeader className="mb-[1.2rem] h-[8.4rem] w-[14.7rem] rounded-[1.2rem] p-0">
+      <Card className="w-[17.1rem] overflow-hidden p-[1.2rem] tablet:w-[33.2rem] tablet:p-[1.6rem] desktop:w-[31.2rem]">
+        <CardHeader className="mb-[1.2rem] h-[8.4rem] w-[14.7rem] rounded-[1.2rem] p-0 tablet:mb-[2rem] tablet:h-[17.1rem] tablet:w-[30rem] desktop:h-[16rem] desktop:w-[28rem]">
           <Image
-            className="h-[8.4rem] w-[14.7rem] object-cover p-0"
+            className="h-[8.4rem] w-[14.7rem] object-cover p-0 tablet:h-[17.1rem] tablet:w-[30rem] desktop:h-[16rem] desktop:w-[28rem]"
             src={shopData.imageUrl}
             alt=""
             width={162}
@@ -74,36 +74,53 @@ export default function ShopsNoticesListItem({
         </CardHeader>
         <CardContent className="p-0">
           <div className="flex flex-col gap-[0.8rem]">
-            <CardTitle className="text-[16px] font-bold leading-[2rem]">
+            <CardTitle className="text-[16px] font-bold leading-[2rem] tablet:text-[2rem] desktop:leading-normal">
               {shopData.name}
             </CardTitle>
-            <div className="flex items-start gap-[0.6rem]">
-              <Image src="/icons/clock.svg" alt="" width={16} height={16} />
-              <CardDescription className="text-[1.2rem] leading-[1.6rem] text-gray-50">
-                {startDay}
-                <br />
-                {startTime}:{minute}~{endTime}:{minute}({item.workhour}
+            <div className="flex items-start gap-[0.6rem] tablet:items-center">
+              <Image
+                className="talbet:w-[2rem] tablet:h-[2rem]"
+                src="/icons/clock.svg"
+                alt=""
+                width={16}
+                height={16}
+              />
+              <CardDescription className="text-[1.2rem] leading-[1.6rem] text-gray-50 tablet:text-[1.4rem] tablet:leading-[2.2rem]">
+                {startDay} <br className="tablet:hidden" />
+                {startTime}:{minute}~{endTime}:{minute} ({item.workhour}
                 시간)
               </CardDescription>
             </div>
             <div className="flex items-center gap-[0.6rem]">
-              <Image src="/icons/point.svg" alt="" width={16} height={16} />
-              <CardDescription className="text-[1.2rem] leading-[1.6rem] text-gray-50">
+              <Image
+                className="talbet:w-[2rem] tablet:h-[2rem]"
+                src="/icons/point.svg"
+                alt=""
+                width={16}
+                height={16}
+              />
+              <CardDescription className="text-[1.2rem] leading-[1.6rem] text-gray-50 tablet:text-[1.4rem]">
                 {shopData.address1}
               </CardDescription>
             </div>
           </div>
         </CardContent>
         <CardFooter className="mt-[1.6rem] p-0">
-          <div className="flex flex-col gap-[0.2rem]">
-            <span className="text-[1.8rem] font-bold">
+          <div className="flex w-[100%] flex-col gap-[0.2rem] tablet:flex-row tablet:items-center tablet:justify-between">
+            <span className="whitespace-nowrap text-[1.8rem] font-bold tablet:text-[2.4rem]">
               {Number(item.hourlyPay).toLocaleString()}원
             </span>
             <div className="flex">
-              <span className={`text-[1.2rem] leading-[1.6rem] text-${color}`}>
-                기존 시급보다 {riseRate}%
-              </span>
-              {riseRate > 0 && <ArrowUpIconCustom color={color} />}
+              <div
+                className={`flex tablet:h-[3.6rem] tablet:items-center tablet:rounded-[2rem] tablet:bg-${color} tablet:p-[1.2rem]`}
+              >
+                <span
+                  className={`text-${color} whitespace-nowrap text-[1.2rem] leading-[1.6rem] tablet:text-[1.4rem] tablet:font-bold tablet:text-white`}
+                >
+                  기존 시급보다 {riseRate}%
+                </span>
+                {riseRate > 0 && <ArrowUpIconCustom color={color} />}
+              </div>
             </div>
           </div>
         </CardFooter>

--- a/src/components/shop/ShopsNoticesListItem.tsx
+++ b/src/components/shop/ShopsNoticesListItem.tsx
@@ -31,7 +31,7 @@ const colorCalculate = (num: number) => {
   if (num >= 40) return "red-40";
   else if (num >= 30) return "red-30";
   else if (num >= 20) return "red-20";
-  else return "red-10";
+  else if (num >= 10) return "red-10";
 };
 
 export const timeCalculate = (time: string, workhour: number) => {
@@ -61,44 +61,53 @@ export default function ShopsNoticesListItem({
   const color = colorCalculate(riseRate);
 
   return (
-    <>
-      <Card className="w-auto max-w-[37.5rem]">
-        <CardHeader>
-          <Image src={shopData.imageUrl} alt="" width={162} height={148} />
+    <div>
+      <Card className="w-[17.1rem] p-[1.2rem]">
+        <CardHeader className="mb-[1.2rem] h-[8.4rem] w-[14.7rem] rounded-[1.2rem] p-0">
+          <Image
+            className="h-[8.4rem] w-[14.7rem] object-cover p-0"
+            src={shopData.imageUrl}
+            alt=""
+            width={162}
+            height={148}
+          />
         </CardHeader>
-        <CardContent>
-          <div className="flex flex-col gap-[1rem]">
-            <CardTitle>{shopData.name}</CardTitle>
-            <div className="flex items-start gap-[0.5rem]">
+        <CardContent className="p-0">
+          <div className="flex flex-col gap-[0.8rem]">
+            <CardTitle className="text-[16px] font-bold leading-[2rem]">
+              {shopData.name}
+            </CardTitle>
+            <div className="flex items-start gap-[0.6rem]">
               <Image src="/icons/clock.svg" alt="" width={16} height={16} />
-              <div>
-                <CardDescription>{startDay}</CardDescription>
-                <CardDescription>
-                  {startTime}:{minute}~{endTime}:{minute}({item.workhour}
-                  시간)
-                </CardDescription>
-              </div>
+              <CardDescription className="text-[1.2rem] leading-[1.6rem] text-gray-50">
+                {startDay}
+                <br />
+                {startTime}:{minute}~{endTime}:{minute}({item.workhour}
+                시간)
+              </CardDescription>
             </div>
-            <div className="flex items-center gap-[0.5rem]">
+            <div className="flex items-center gap-[0.6rem]">
               <Image src="/icons/point.svg" alt="" width={16} height={16} />
-              <CardDescription>{shopData.address1}</CardDescription>
+              <CardDescription className="text-[1.2rem] leading-[1.6rem] text-gray-50">
+                {shopData.address1}
+              </CardDescription>
             </div>
           </div>
         </CardContent>
-        <CardFooter>
-          <div className="flex flex-col">
-            <span className="text-[1.8rem] font-[700] text-black">
-              {item.hourlyPay}원
+        <CardFooter className="mt-[1.6rem] p-0">
+          <div className="flex flex-col gap-[0.2rem]">
+            <span className="text-[1.8rem] font-bold">
+              {Number(item.hourlyPay).toLocaleString()}원
             </span>
             <div className="flex">
-              <span className={`text-[1.2rem] font-[400] text-${color}`}>
+              <span className={`text-[1.2rem] leading-[1.6rem] text-${color}`}>
                 기존 시급보다 {riseRate}%
               </span>
-              <ArrowUpIconCustom color={color} />
+              {riseRate > 0 && <ArrowUpIconCustom color={color} />}
             </div>
           </div>
         </CardFooter>
       </Card>
-    </>
+    </div>
   );
 }

--- a/src/components/ui/ArrowUpIconCustom.tsx
+++ b/src/components/ui/ArrowUpIconCustom.tsx
@@ -1,11 +1,11 @@
-export default function ArrowUpIconCustom({ color = "white" }) {
+export default function ArrowUpIconCustom({ color = "black" }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="16"
       height="17"
       viewBox="0 0 16 17"
-      className={`fill-${color}`}
+      className={`fill-${color} tablet:h-[2rem] tablet:w-[2rem] tablet:fill-white`}
     >
       <path d="M10.0001 13.5483H6.0001V8.21495H2.77344L8.0001 2.98828L13.2268 8.21495H10.0001V13.5483Z" />
     </svg>


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #130 
- 사장님 가게 정보 상세 페이지에서 공고 리스트의 세부 디자인과 반응형 웹이 필요함

# 어떤 변화가 생겼나요?
- 가게 정보 상세 내 공고 리스트와 리스트 아이템 디자인 / 반응형 구현

# 스크린샷(optional)
- 모바일
<img width="294" alt="스크린샷 2024-02-04 181033" src="https://github.com/S2-P3-T5/Julge/assets/144401634/fc009473-3655-4efb-9a28-1361ed7ed969">

- 태블릿
<img width="540" alt="스크린샷 2024-02-04 181210" src="https://github.com/S2-P3-T5/Julge/assets/144401634/34fd79b4-b7bd-44d4-8161-2f13ffad215c">

- 데스크탑
<img width="777" alt="스크린샷 2024-02-04 181226" src="https://github.com/S2-P3-T5/Julge/assets/144401634/58791c57-c216-4885-bbdb-b2b21ff5cb1a">
