### PR TITLE
사장님: 가게 정보 등록 / 편집 미리보기 이미지 비율 안맞는 현상 수정

### DIFF
--- a/src/components/shop/ShopImageCard.tsx
+++ b/src/components/shop/ShopImageCard.tsx
@@ -10,7 +10,7 @@ export default function ShopImageCard({ imgURL }: ShopImageCardProps) {
         {imgURL ? (
           <div className="h-[20rem] w-[35.1rem] overflow-hidden tablet:h-[27.6rem] tablet:w-[48.3rem]">
             <Image
-              className="object-cover tablet:h-[27.6rem] tablet:w-[48.3rem]"
+              className="cursor-pointer object-cover tablet:h-[27.6rem] tablet:w-[48.3rem]"
               src={imgURL}
               height="200"
               width="351"

--- a/src/components/shop/ShopImageCard.tsx
+++ b/src/components/shop/ShopImageCard.tsx
@@ -10,6 +10,7 @@ export default function ShopImageCard({ imgURL }: ShopImageCardProps) {
         {imgURL ? (
           <div className="h-[20rem] w-[35.1rem] overflow-hidden tablet:h-[27.6rem] tablet:w-[48.3rem]">
             <Image
+              className="object-cover tablet:h-[27.6rem] tablet:w-[48.3rem]"
               src={imgURL}
               height="200"
               width="351"


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #134 
- 미리보기 이미지 비율이 맞지 않아 수정이 필요함

# 어떤 변화가 생겼나요?
- 미리보기 이미지가 알맞은 레이아웃에 맞게 표시됨.
- 미리보기 이미지 있을 경우 이미지 변경 가능 표시를 위한 마우스 커서 포인터 표시

# 스크린샷(optional)
- 수정 전
<img width="491" alt="스크린샷 2024-02-04 184009" src="https://github.com/S2-P3-T5/Julge/assets/144401634/461ecbb1-cd1c-405c-a655-6086acc05268">

- 수정 후
<img width="590" alt="스크린샷 2024-02-04 183930" src="https://github.com/S2-P3-T5/Julge/assets/144401634/ae3e14d5-322b-42f3-be4b-5b2358e62d61">
