### PR TITLE
feat:사장님 가게 상세 페이지에서 공고 선택 시 공고 상세 페이지로 이동 구현

### DIFF
--- a/src/components/shop/ShopsNoticesList.tsx
+++ b/src/components/shop/ShopsNoticesList.tsx
@@ -1,7 +1,9 @@
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { getNewNoticesListData } from "@/apis/shops";
 import ShopsNoticesListItem from "@/components/shop/ShopsNoticesListItem";
+import { PAGE_ROUTES } from "@/routes";
 
 interface ShopsNoticesListProps {
   noticesListData: {
@@ -78,7 +80,14 @@ export default function ShopsNoticesList({
         <div className="flex w-[35.1rem] flex-wrap justify-between gap-x-[0.9rem] gap-y-[1.6rem] tablet:w-[67.8rem] tablet:gap-y-[3.2rem] desktop:w-[96.4rem]">
           {itemList.map((item: any) => (
             <li key={item.item.id}>
-              <ShopsNoticesListItem item={item.item} shopData={shopData} />
+              <Link
+                href={PAGE_ROUTES.parseShopNoticeApplicationsURL(
+                  shopData.id,
+                  item.item.id,
+                )}
+              >
+                <ShopsNoticesListItem item={item.item} shopData={shopData} />
+              </Link>
             </li>
           ))}
         </div>


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #138 
- 가게 상세 페이지에서 공고를 선택했을 때 해당 공고의 상세페이지로 이동할 수 있어야 한다.

# 어떤 변화가 생겼나요?
- 공고 선택시 해당 공고의 상세페이지로 이동

# 스크린샷(optional)
![공고 상세 이동](https://github.com/S2-P3-T5/Julge/assets/144401634/650af1ec-9b8f-40e0-8f99-392c81040660)

