### PR TITLE
공통: http 에러 body의 message를 에러 메세지로 할당

### DIFF
--- a/src/apis/fetcher.ts
+++ b/src/apis/fetcher.ts
@@ -58,4 +58,21 @@ class KyAdapter implements Fetcher {
   }
 }
 
-export const fetcher = new KyAdapter(ky.create({ prefixUrl: API_ROUTE }));
+export const fetcher = new KyAdapter(
+  ky.create({
+    prefixUrl: API_ROUTE,
+    hooks: {
+      beforeError: [
+        async (err) => {
+          const { response } = err;
+          if (response && response.body) {
+            const { message } = await response.json();
+            err.message = message;
+          }
+
+          return err;
+        },
+      ],
+    },
+  }),
+);


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #142 
-

# 어떤 변화가 생겼나요?

- fetcher에 beforeErrror 훅 추가
  - 에러 발생 시에 response body의 message를 Error.message에 할당

# 스크린샷(optional)
