### PR TITLE
사장님: /shops 기본 페이지 구현 및 접근 권한에 맞는 페이지 이동 구현

### DIFF
--- a/src/apis/shop/index.ts
+++ b/src/apis/shop/index.ts
@@ -7,8 +7,8 @@ export const getShopsData = async (shopId: string) => {
     const res = await fetcher.get(apiRouteUtils.parseShopsURL(shopId));
     const result = await res.json();
     return result;
-  } catch (e: any) {
-    throw e;
+  } catch (err: any) {
+    throw err;
   }
 };
 
@@ -69,4 +69,12 @@ export const putShopEditData = async (
   } catch (err: any) {
     throw err;
   }
+};
+
+export const getUsersData = async (userId: string) => {
+  try {
+    const res = await fetcher.get(`${apiRouteUtils.USERS}/${userId}`);
+    const result = await res.json();
+    return result;
+  } catch {}
 };

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -2,7 +2,7 @@ import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 
 import { getUsersData } from "@/apis/shop";
-import EmployerHeader from "@/components/common/EmployerHeader";
+import EmployerLayout from "@/components/common/EmployerLayout";
 import EmptyDataCard from "@/components/shop/EmptyDataCard";
 import { getAccessTokenInStorage } from "@/helpers/auth";
 import { UserContext } from "@/providers/UserProvider";
@@ -39,13 +39,14 @@ export default function ShopsDefaultPage() {
     <div>임시로딩중</div>
   ) : (
     <>
-      <EmployerHeader></EmployerHeader>
-      <EmptyDataCard
-        title="내 가게"
-        description="내 가게를 소개하고 공고도 등록해 보세요."
-        buttonText="가게 등록하기"
-        buttonLink={PAGE_ROUTES.SHOPS_REGISTER}
-      />
+      <EmployerLayout>
+        <EmptyDataCard
+          title="내 가게"
+          description="내 가게를 소개하고 공고도 등록해 보세요."
+          buttonText="가게 등록하기"
+          buttonLink={PAGE_ROUTES.SHOPS_REGISTER}
+        />
+      </EmployerLayout>
     </>
   );
 }

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -1,0 +1,51 @@
+import { useRouter } from "next/router";
+import { useContext, useEffect, useState } from "react";
+
+import { getUsersData } from "@/apis/shop";
+import EmployerHeader from "@/components/common/EmployerHeader";
+import EmptyDataCard from "@/components/shop/EmptyDataCard";
+import { getAccessTokenInStorage } from "@/helpers/auth";
+import { UserContext } from "@/providers/UserProvider";
+import { PAGE_ROUTES } from "@/routes";
+
+export default function ShopsDefaultPage() {
+  const user = useContext(UserContext);
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!getAccessTokenInStorage()) {
+      router.push(PAGE_ROUTES.SIGNIN);
+      return;
+    }
+    if (user?.type === "employee") {
+      router.push(PAGE_ROUTES.NOTICES);
+      return;
+    }
+    if (user) {
+      const getUserData = async () => {
+        const response: any = await getUsersData(user.id);
+        if (response.item.shop) {
+          router.push(PAGE_ROUTES.parseShopsURL(response.item.shop.id));
+          return;
+        }
+      };
+      getUserData();
+      setIsLoading(false);
+    }
+  }, [user]);
+
+  return isLoading ? (
+    <div>임시로딩중</div>
+  ) : (
+    <>
+      <EmployerHeader></EmployerHeader>
+      <EmptyDataCard
+        title="내 가게"
+        description="내 가게를 소개하고 공고도 등록해 보세요."
+        buttonText="가게 등록하기"
+        buttonLink={PAGE_ROUTES.SHOPS_REGISTER}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #120 
- 사장님 계정 최초 생성시 shopId가 없으므로 기본 /shops 페이지가 필요함.

# 어떤 변화가 생겼나요?
- 로그인 상태가 아니거나 로그아웃 시 /signin 페이지로 이동
- 회원이 사장이 아닐시 /notices 페이지로 이동
- 자기 가게가 있을 경우 해당 /shops/[shopId]로 이동 (스크린샷 없음)

# 스크린샷(optional)
- 로그인 상태가 아닐 때 접근
![로그인안했을때](https://github.com/S2-P3-T5/Julge/assets/144401634/2fbbf148-a0a4-4b48-9dda-6968a40335ca)

- 로그아웃 시
![로그아웃](https://github.com/S2-P3-T5/Julge/assets/144401634/62faad41-fbb4-4605-9328-37c2822f6b09)

- 사장님이 아닐 경우
![알바가접근](https://github.com/S2-P3-T5/Julge/assets/144401634/0be8bbf2-2df2-40d4-bd49-c2573ffa83d4)

