### PR TITLE
공통: 공고리스트 - 페이지 전체공고 페이지네이션 구현

### DIFF
--- a/src/apis/notice/index.ts
+++ b/src/apis/notice/index.ts
@@ -38,11 +38,10 @@ export const postNoticeRegistration = async (
     });
 };
 
-export const getAllNoticesListData = async () => {
+export const getNoticesListData = async (offset = 0) => {
   try {
-    //TODO: 페이지네이션에 맞게 offset 변경예정
     const response = await fetcher.get(
-      apiRouteUtils.NOTICES + "?offset=46&limit=6",
+      apiRouteUtils.NOTICES + `?offset=${offset}&limit=6`,
     );
     const result = await response.json();
     return result;

--- a/src/components/notices/NoticeListPagination.tsx
+++ b/src/components/notices/NoticeListPagination.tsx
@@ -1,17 +1,12 @@
-import { Fragment } from "react";
-
 import {
   Pagination,
   PaginationContent,
+  PaginationEllipsis,
   PaginationItem,
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
-
-function generateArray(n: number) {
-  return Array.from({ length: n }, (_, index) => index + 1);
-}
 
 interface NoticeListPagination {
   count: number;
@@ -25,11 +20,7 @@ export default function NoticeListPagination({
   page,
 }: NoticeListPagination) {
   const pageCount = Math.ceil(count / 6);
-  const pageArr: number[] = generateArray(pageCount);
 
-  const handlePageClick = (p: number) => {
-    handlePage(p);
-  };
   const handlePrePageClick = () => {
     if (page > 1) {
       handlePage(page - 1);
@@ -41,25 +32,17 @@ export default function NoticeListPagination({
     }
   };
 
-  //TODO: 표시되는 페이지 숫자 수정
   return (
-    <Pagination>
+    <Pagination className="mb-[6rem]">
       <PaginationContent>
         <PaginationItem className="cursor-pointer" onClick={handlePrePageClick}>
           <PaginationPrevious />
         </PaginationItem>
-        {pageArr.map((p) => {
-          return (
-            <Fragment key={p}>
-              <PaginationItem
-                onClick={() => handlePageClick(p)}
-                className="cursor-pointer"
-              >
-                <PaginationLink isActive={p === page}>{p}</PaginationLink>
-              </PaginationItem>
-            </Fragment>
-          );
-        })}
+        {page > 1 && <PaginationEllipsis />}
+        <PaginationItem className="cursor-pointer">
+          <PaginationLink isActive>{page}</PaginationLink>
+        </PaginationItem>
+        {page < pageCount && <PaginationEllipsis />}
         <PaginationItem
           className="cursor-pointer"
           onClick={handleNextPageClick}

--- a/src/components/notices/NoticeListPagination.tsx
+++ b/src/components/notices/NoticeListPagination.tsx
@@ -1,36 +1,70 @@
+import { Fragment } from "react";
+
 import {
   Pagination,
   PaginationContent,
-  PaginationEllipsis,
   PaginationItem,
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
 
-export default function NoticeListPagination() {
+function generateArray(n: number) {
+  return Array.from({ length: n }, (_, index) => index + 1);
+}
+
+interface NoticeListPagination {
+  count: number;
+  handlePage: (num: number) => void;
+  page: number;
+}
+
+export default function NoticeListPagination({
+  count,
+  handlePage,
+  page,
+}: NoticeListPagination) {
+  const pageCount = Math.ceil(count / 6);
+  const pageArr: number[] = generateArray(pageCount);
+
+  const handlePageClick = (p: number) => {
+    handlePage(p);
+  };
+  const handlePrePageClick = () => {
+    if (page > 1) {
+      handlePage(page - 1);
+    }
+  };
+  const handleNextPageClick = () => {
+    if (page < pageCount) {
+      handlePage(page + 1);
+    }
+  };
+
+  //TODO: 표시되는 페이지 숫자 수정
   return (
     <Pagination>
       <PaginationContent>
-        <PaginationItem>
-          <PaginationPrevious href="#" />
+        <PaginationItem className="cursor-pointer" onClick={handlePrePageClick}>
+          <PaginationPrevious />
         </PaginationItem>
-        <PaginationItem>
-          <PaginationLink href="#">1</PaginationLink>
-        </PaginationItem>
-        <PaginationItem>
-          <PaginationLink href="#" isActive>
-            2
-          </PaginationLink>
-        </PaginationItem>
-        <PaginationItem>
-          <PaginationLink href="#">3</PaginationLink>
-        </PaginationItem>
-        <PaginationItem>
-          <PaginationEllipsis />
-        </PaginationItem>
-        <PaginationItem>
-          <PaginationNext href="#" />
+        {pageArr.map((p) => {
+          return (
+            <Fragment key={p}>
+              <PaginationItem
+                onClick={() => handlePageClick(p)}
+                className="cursor-pointer"
+              >
+                <PaginationLink isActive={p === page}>{p}</PaginationLink>
+              </PaginationItem>
+            </Fragment>
+          );
+        })}
+        <PaginationItem
+          className="cursor-pointer"
+          onClick={handleNextPageClick}
+        >
+          <PaginationNext />
         </PaginationItem>
       </PaginationContent>
     </Pagination>

--- a/src/components/notices/NoticeLists.tsx
+++ b/src/components/notices/NoticeLists.tsx
@@ -7,15 +7,29 @@ import NoticeListPopover from "@/components/notices/NoticeListPopover";
 import ShopsNoticesListItem from "@/components/shop/ShopsNoticesListItem";
 
 export default function NoticesLists() {
-  const [allNoticesList, setAllNoticesList] = useState<any>("");
+  const [allNoticesList, setAllNoticesList] = useState([]);
+  const [options, setOptions] = useState({
+    address: [],
+    count: 0,
+    hasNext: true,
+    limit: 6,
+    offset: 0,
+  });
   const [customNoticesList, setCustomNoticesList] = useState<any>("");
 
   useEffect(() => {
     const getData = async () => {
       const resultAllNotices: any = await getAllNoticesListData();
       const resultCustomNotices: any = await getCustomNoticesListData();
-      setAllNoticesList(resultAllNotices);
       setCustomNoticesList(resultCustomNotices);
+      setAllNoticesList(resultAllNotices.items);
+      setOptions({
+        address: resultAllNotices.address,
+        count: resultAllNotices.count,
+        hasNext: resultAllNotices.hasNext,
+        limit: 6,
+        offset: resultAllNotices.offset,
+      });
     };
     getData();
   }, []);
@@ -26,7 +40,7 @@ export default function NoticesLists() {
       <div className="bg-red-10">
         <ul className="mx-auto flex w-[35.1rem] flex-col gap-[1.6rem] pb-[8rem] pt-[4rem] tablet:w-[67.8rem] tablet:gap-[3.2rem] tablet:pb-[12rem] tablet:pt-[6rem] desktop:w-[96.4rem]">
           <span className="text-[2rem] font-bold tablet:text-[2.8rem]">
-            전체 공고
+            맞춤 공고
           </span>
           <div className="flex w-[37.1rem] justify-between gap-x-[0.9rem] gap-y-[1.6rem] overflow-scroll scrollbar-hide tablet:w-[69.8rem] tablet:gap-y-[3.2rem] desktop:w-[98.4rem]">
             {customNoticesList &&
@@ -51,7 +65,7 @@ export default function NoticesLists() {
           <NoticeListPopover />
           <div className="flex w-[35.1rem] flex-wrap justify-between gap-x-[0.9rem] gap-y-[1.6rem] tablet:w-[67.8rem] tablet:gap-y-[3.2rem] desktop:w-[96.4rem]">
             {allNoticesList &&
-              allNoticesList.items.map((item: any) => (
+              allNoticesList.map((item: any) => (
                 <li key={item.item.id}>
                   <ShopsNoticesListItem
                     item={item.item}

--- a/src/components/notices/NoticeLists.tsx
+++ b/src/components/notices/NoticeLists.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from "react";
 
-import { getAllNoticesListData, getCustomNoticesListData } from "@/apis/notice";
+import { getCustomNoticesListData, getNoticesListData } from "@/apis/notice";
 import NoticeListDropdownMenu from "@/components/notices/NoticeListDropDownMenu";
 import NoticeListPagination from "@/components/notices/NoticeListPagination";
 import NoticeListPopover from "@/components/notices/NoticeListPopover";
 import ShopsNoticesListItem from "@/components/shop/ShopsNoticesListItem";
 
 export default function NoticesLists() {
-  const [allNoticesList, setAllNoticesList] = useState([]);
+  const [page, setPage] = useState(1);
+  const [noticesList, setNoticesList] = useState([]);
   const [options, setOptions] = useState({
     address: [],
     count: 0,
@@ -19,10 +20,10 @@ export default function NoticesLists() {
 
   useEffect(() => {
     const getData = async () => {
-      const resultAllNotices: any = await getAllNoticesListData();
+      const resultAllNotices: any = await getNoticesListData();
       const resultCustomNotices: any = await getCustomNoticesListData();
       setCustomNoticesList(resultCustomNotices);
-      setAllNoticesList(resultAllNotices.items);
+      setNoticesList(resultAllNotices.items);
       setOptions({
         address: resultAllNotices.address,
         count: resultAllNotices.count,
@@ -33,6 +34,19 @@ export default function NoticesLists() {
     };
     getData();
   }, []);
+
+  useEffect(() => {
+    const getData = async () => {
+      const newOffset = (page - 1) * 6;
+      const resultAllNotices: any = await getNoticesListData(newOffset);
+      setNoticesList(resultAllNotices.items);
+    };
+    getData();
+  }, [page]);
+
+  const handlePage = (num: number) => {
+    setPage(num);
+  };
 
   // TODO : 타입수정, items 분리 ?, 로딩처리
   return (
@@ -64,8 +78,8 @@ export default function NoticesLists() {
           <NoticeListDropdownMenu />
           <NoticeListPopover />
           <div className="flex w-[35.1rem] flex-wrap justify-between gap-x-[0.9rem] gap-y-[1.6rem] tablet:w-[67.8rem] tablet:gap-y-[3.2rem] desktop:w-[96.4rem]">
-            {allNoticesList &&
-              allNoticesList.map((item: any) => (
+            {noticesList &&
+              noticesList.map((item: any) => (
                 <li key={item.item.id}>
                   <ShopsNoticesListItem
                     item={item.item}
@@ -76,7 +90,11 @@ export default function NoticesLists() {
           </div>
         </ul>
       </div>
-      <NoticeListPagination />
+      <NoticeListPagination
+        handlePage={handlePage}
+        count={options.count}
+        page={page}
+      />
     </>
   );
 }


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #165 
- 공고리스트 페이지에서 페이지 버튼으로 다른 공고를 확인할 수 있어야 한다.

# 어떤 변화가 생겼나요?
-/notices 페이지 페이지네이션 구현

# 스크린샷(optional)
- 페이지네이션 목록 수정 후
![notices 페이지네이션 수정](https://github.com/S2-P3-T5/Julge/assets/144401634/49d96057-5936-4027-aa99-c47f26942d28)


