### PR TITLE
내 프로필: 빈 프로필 카드 구현

### DIFF
--- a/src/components/my/EmptyProfileCard.tsx
+++ b/src/components/my/EmptyProfileCard.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardDescription } from "@/components/ui/card";
+import { PAGE_ROUTES } from "@/routes";
+
+export default function EmptyProfileCard() {
+  return (
+    <Card className="flex flex-col items-center justify-center gap-[16px] rounded-[8px] py-[60px]">
+      <CardDescription className="text-[1.4rem] text-black">
+        내 프로필을 등록하고 원하는 가게에 지원해보세요.
+      </CardDescription>
+      <Button
+        className="h-max rounded-[8px] px-[20px] py-[10px] text-[1.4rem] font-bold"
+        asChild
+      >
+        <Link href={PAGE_ROUTES.MY_REGISTER}>내 프로필 등록하기</Link>
+      </Button>
+    </Card>
+  );
+}

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -1,4 +1,5 @@
 import EmployeeLayout from "@/components/common/EmployeeLayout";
+import EmptyProfileCard from "@/components/my/EmptyProfileCard";
 
 export default function My() {
   return (
@@ -8,7 +9,9 @@ export default function My() {
           <header>
             <h2 className="text-[2rem] font-bold">내 프로필</h2>
           </header>
-          <div className="mt-[16px]"></div>
+          <div className="mt-[16px]">
+            <EmptyProfileCard />
+          </div>
         </div>
       </section>
     </EmployeeLayout>

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -6,6 +6,7 @@ export const PAGE_ROUTES = {
   SHOPS_REGISTER: "/shops/register",
   SHOPS: "/shops",
   MY: "/my",
+  MY_REGISTER: "/my/register",
   parseShopsURL: (shopId: string) => `/shops/${shopId}`,
   parseShopsEditURL: (shopId: string) => `/shops/edit/${shopId}`,
   parseNoticeRegisterURL: (shopId: string) =>


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #162 
- 프로필이 없을 때 프로필 등록으로 이동할 수 있는 수단

# 어떤 변화가 생겼나요?

- 프로필이 없을 경우 띄우는 카드 디자인 구현
- 프로필 등록 버튼을 누를 시 프로필 등록 페이지로 이동

# 스크린샷(optional)

https://github.com/S2-P3-T5/Julge/assets/29909393/a49daccb-6c37-4572-9ca0-6c02a43cb1ff

