### PR TITLE
공통: 공고리스트 공고 클릭 시 해당 공고 지원 페이지 이동

### DIFF
--- a/src/components/notices/NoticeLists.tsx
+++ b/src/components/notices/NoticeLists.tsx
@@ -81,13 +81,18 @@ export default function NoticesLists() {
           <NoticeListPopover />
           <div className="flex w-[35.1rem] flex-wrap justify-between gap-x-[0.9rem] gap-y-[1.6rem] tablet:w-[67.8rem] tablet:gap-y-[3.2rem] desktop:w-[96.4rem]">
             {noticesList &&
-              noticesList.map((item: any) => (
+              noticesList.map((data: any) => (
                 <>
-                  <Link href={PAGE_ROUTES.parseNotciesApplyURL(item.item.id)}>
-                    <li key={item.item.id}>
+                  <Link
+                    href={PAGE_ROUTES.parseNotciesApplyURL(
+                      data.item.shop.item.id,
+                      data.item.id,
+                    )}
+                  >
+                    <li key={data.item.id}>
                       <ShopsNoticesListItem
-                        item={item.item}
-                        shopData={item.item.shop.item}
+                        item={data.item}
+                        shopData={data.item.shop.item}
                       />
                     </li>
                   </Link>

--- a/src/components/notices/NoticeLists.tsx
+++ b/src/components/notices/NoticeLists.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { getCustomNoticesListData, getNoticesListData } from "@/apis/notice";
@@ -5,6 +6,7 @@ import NoticeListDropdownMenu from "@/components/notices/NoticeListDropDownMenu"
 import NoticeListPagination from "@/components/notices/NoticeListPagination";
 import NoticeListPopover from "@/components/notices/NoticeListPopover";
 import ShopsNoticesListItem from "@/components/shop/ShopsNoticesListItem";
+import { PAGE_ROUTES } from "@/routes";
 
 export default function NoticesLists() {
   const [page, setPage] = useState(1);
@@ -80,12 +82,16 @@ export default function NoticesLists() {
           <div className="flex w-[35.1rem] flex-wrap justify-between gap-x-[0.9rem] gap-y-[1.6rem] tablet:w-[67.8rem] tablet:gap-y-[3.2rem] desktop:w-[96.4rem]">
             {noticesList &&
               noticesList.map((item: any) => (
-                <li key={item.item.id}>
-                  <ShopsNoticesListItem
-                    item={item.item}
-                    shopData={item.item.shop.item}
-                  />
-                </li>
+                <>
+                  <Link href={PAGE_ROUTES.parseNotciesApplyURL(item.item.id)}>
+                    <li key={item.item.id}>
+                      <ShopsNoticesListItem
+                        item={item.item}
+                        shopData={item.item.shop.item}
+                      />
+                    </li>
+                  </Link>
+                </>
               ))}
           </div>
         </ul>

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -15,7 +15,8 @@ export const PAGE_ROUTES = {
     `/shops/${shopId}/notices/register`,
   parseShopNoticeApplicationsURL: (shopId: string, noticeId: string) =>
     `/shops/${shopId}/notices/${noticeId}`,
-  parseNotciesApplyURL: (noticeId: string) => `/notices/${noticeId}/apply`,
+  parseNotciesApplyURL: (shopId: string, noticeId: string) =>
+    `/shops/${shopId}/notices/${noticeId}/apply`,
 };
 
 export const API_ROUTE = process.env.NEXT_PUBLIC_API_ENDPOINT;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -15,6 +15,7 @@ export const PAGE_ROUTES = {
     `/shops/${shopId}/notices/register`,
   parseShopNoticeApplicationsURL: (shopId: string, noticeId: string) =>
     `/shops/${shopId}/notices/${noticeId}`,
+  parseNotciesApplyURL: (noticeId: string) => `/notices/${noticeId}/apply`,
 };
 
 export const API_ROUTE = process.env.NEXT_PUBLIC_API_ENDPOINT;


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #176 
- 공고 클릭시 해당 공고 지원페이지로 이동할 수 있어야 함

# 어떤 변화가 생겼나요?
- 공고 클릭시 해당 공고 지원페이지로 이동

# 스크린샷(optional)
