### PR TITLE
공통: 맞춤 공고 carousel 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@tanstack/react-query-devtools": "^5.17.15",
     "class-variance-authority": "^0.7.0",
     "cmdk": "^0.2.0",
+    "embla-carousel-react": "8.0.0-rc22",
     "jwt-decode": "^4.0.0",
     "ky": "^1.2.0",
     "lucide-react": "^0.311.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   cmdk:
     specifier: ^0.2.0
     version: 0.2.0(@types/react@18.2.48)(react-dom@18.2.0)(react@18.2.0)
+  embla-carousel-react:
+    specifier: 8.0.0-rc22
+    version: 8.0.0-rc22(react@18.2.0)
   jwt-decode:
     specifier: ^4.0.0
     version: 4.0.0
@@ -1931,6 +1934,28 @@ packages:
   /electron-to-chromium@1.4.635:
     resolution: {integrity: sha512-iu/2D0zolKU3iDGXXxdOzNf72Jnokn+K1IN6Kk4iV6l1Tr2g/qy+mvmtfAiBwZe5S3aB5r92vp+zSZ69scYRrg==}
     dev: true
+
+  /embla-carousel-react@8.0.0-rc22(react@18.2.0):
+    resolution: {integrity: sha512-NwmISV0Cw9XVo76Vquz3hJaeZe7qoCRtrzStxlEY7qfZD8WR/f4JlQAso35URTs1BeYVhcuClflelioo+Zmidg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0
+    dependencies:
+      embla-carousel: 8.0.0-rc22
+      embla-carousel-reactive-utils: 8.0.0-rc22(embla-carousel@8.0.0-rc22)
+      react: 18.2.0
+    dev: false
+
+  /embla-carousel-reactive-utils@8.0.0-rc22(embla-carousel@8.0.0-rc22):
+    resolution: {integrity: sha512-K4b8QhQGXYW5wr4l+U6XryhafsFV5c/IyohDnZN3MGoYIB9xY7qpjUWAcs5bTDjAD+qCZPOuXre0D3IVa28mqw==}
+    peerDependencies:
+      embla-carousel: 8.0.0-rc22
+    dependencies:
+      embla-carousel: 8.0.0-rc22
+    dev: false
+
+  /embla-carousel@8.0.0-rc22:
+    resolution: {integrity: sha512-MeXnPT1LShfgAu8qXj3CskayV0R6OkHx7w3cPTx+Q5ZWKyShKpIuu7qVQJ5BoFegalE4n6yxqoQaRuGFbK9pYw==}
+    dev: false
 
   /emoji-regex@10.3.0:
     resolution: {integrity: sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==}

--- a/src/apis/notice/index.ts
+++ b/src/apis/notice/index.ts
@@ -83,11 +83,10 @@ export const getNoticesListData = async (offset = 0) => {
   }
 };
 
-export const getCustomNoticesListData = async () => {
+export const getCustomNoticesListData = async (address = "") => {
   try {
-    //TODO : query 사용자의 주소에 맞게 수정 해야함
     const response = await fetcher.get(
-      apiRouteUtils.NOTICES + `?offset=0&limit=6&address=${"서울시 중구"}`,
+      apiRouteUtils.NOTICES + `?offset=0&limit=10&address=${address}`,
     );
     const result = await response.json();
     return result;

--- a/src/components/notices/NoticeLists.tsx
+++ b/src/components/notices/NoticeLists.tsx
@@ -5,6 +5,13 @@ import NoticeListDropdownMenu from "@/components/notices/NoticeListDropDownMenu"
 import NoticeListPagination from "@/components/notices/NoticeListPagination";
 import NoticeListPopover from "@/components/notices/NoticeListPopover";
 import ShopsNoticesListItem from "@/components/shop/ShopsNoticesListItem";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
 import { UserContext } from "@/providers/UserProvider";
 
 export default function NoticesLists() {
@@ -24,7 +31,7 @@ export default function NoticesLists() {
     const getData = async () => {
       const resultAllNotices: any = await getNoticesListData();
       const resultCustomNotices: any = await getCustomNoticesListData(
-        user.address,
+        user?.address,
       );
       setCustomNoticesList(resultCustomNotices.items);
       setNoticesList(resultAllNotices.items);
@@ -52,7 +59,6 @@ export default function NoticesLists() {
     setPage(num);
   };
 
-  // TODO : 타입수정, items 분리 ?, 로딩처리
   return (
     <>
       <div className="bg-red-10">
@@ -60,17 +66,27 @@ export default function NoticesLists() {
           <span className="text-[2rem] font-bold tablet:text-[2.8rem]">
             맞춤 공고
           </span>
-          <div className="flex w-[37.1rem] justify-between gap-x-[0.9rem] gap-y-[1.6rem] overflow-scroll scrollbar-hide tablet:w-[69.8rem] tablet:gap-y-[3.2rem] desktop:w-[98.4rem]">
-            {customNoticesList &&
-              customNoticesList.map((data: any) => (
-                <li key={data.item.id}>
-                  <ShopsNoticesListItem
-                    item={data.item}
-                    shopData={data.item.shop.item}
-                  />
-                </li>
-              ))}
-          </div>
+          <Carousel>
+            <div className="flex w-[35.1rem] flex-wrap justify-between gap-x-[0.9rem] gap-y-[1.6rem] tablet:w-[67.8rem] tablet:gap-y-[3.2rem] desktop:w-[96.4rem]">
+              <CarouselContent>
+                {customNoticesList &&
+                  customNoticesList.map((data: any) => (
+                    <>
+                      <CarouselItem className="basis-100">
+                        <li key={data.item.id}>
+                          <ShopsNoticesListItem
+                            item={data.item}
+                            shopData={data.item.shop.item}
+                          />
+                        </li>
+                      </CarouselItem>
+                    </>
+                  ))}
+              </CarouselContent>
+              <CarouselPrevious className="h-[24px] w-[24px]" />
+              <CarouselNext className="h-[24px] w-[24px]" />
+            </div>
+          </Carousel>
         </ul>
       </div>
 

--- a/src/components/notices/NoticeLists.tsx
+++ b/src/components/notices/NoticeLists.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 
 import { getCustomNoticesListData, getNoticesListData } from "@/apis/notice";
 import NoticeListDropdownMenu from "@/components/notices/NoticeListDropDownMenu";
 import NoticeListPagination from "@/components/notices/NoticeListPagination";
 import NoticeListPopover from "@/components/notices/NoticeListPopover";
 import ShopsNoticesListItem from "@/components/shop/ShopsNoticesListItem";
+import { UserContext } from "@/providers/UserProvider";
 
 export default function NoticesLists() {
+  const user = useContext<any>(UserContext);
   const [page, setPage] = useState(1);
   const [noticesList, setNoticesList] = useState([]);
   const [options, setOptions] = useState({
@@ -16,13 +18,15 @@ export default function NoticesLists() {
     limit: 6,
     offset: 0,
   });
-  const [customNoticesList, setCustomNoticesList] = useState<any>("");
+  const [customNoticesList, setCustomNoticesList] = useState([]);
 
   useEffect(() => {
     const getData = async () => {
       const resultAllNotices: any = await getNoticesListData();
-      const resultCustomNotices: any = await getCustomNoticesListData();
-      setCustomNoticesList(resultCustomNotices);
+      const resultCustomNotices: any = await getCustomNoticesListData(
+        user.address,
+      );
+      setCustomNoticesList(resultCustomNotices.items);
       setNoticesList(resultAllNotices.items);
       setOptions({
         address: resultAllNotices.address,
@@ -58,11 +62,11 @@ export default function NoticesLists() {
           </span>
           <div className="flex w-[37.1rem] justify-between gap-x-[0.9rem] gap-y-[1.6rem] overflow-scroll scrollbar-hide tablet:w-[69.8rem] tablet:gap-y-[3.2rem] desktop:w-[98.4rem]">
             {customNoticesList &&
-              customNoticesList.items.map((item: any) => (
-                <li key={item.item.id}>
+              customNoticesList.map((data: any) => (
+                <li key={data.item.id}>
                   <ShopsNoticesListItem
-                    item={item.item}
-                    shopData={item.item.shop.item}
+                    item={data.item}
+                    shopData={data.item.shop.item}
                   />
                 </li>
               ))}

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,260 @@
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
+
+type CarouselProps = {
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: "horizontal" | "vertical";
+  setApi?: (api: CarouselApi) => void;
+};
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext);
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />");
+  }
+
+  return context;
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = "horizontal",
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === "horizontal" ? "x" : "y",
+      },
+      plugins,
+    );
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+    const [canScrollNext, setCanScrollNext] = React.useState(false);
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) {
+        return;
+      }
+
+      setCanScrollPrev(api.canScrollPrev());
+      setCanScrollNext(api.canScrollNext());
+    }, []);
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev();
+    }, [api]);
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext();
+    }, [api]);
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault();
+          scrollPrev();
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault();
+          scrollNext();
+        }
+      },
+      [scrollPrev, scrollNext],
+    );
+
+    React.useEffect(() => {
+      if (!api || !setApi) {
+        return;
+      }
+
+      setApi(api);
+    }, [api, setApi]);
+
+    React.useEffect(() => {
+      if (!api) {
+        return;
+      }
+
+      onSelect(api);
+      api.on("reInit", onSelect);
+      api.on("select", onSelect);
+
+      return () => {
+        api?.off("select", onSelect);
+      };
+    }, [api, onSelect]);
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api: api,
+          opts,
+          orientation:
+            orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext,
+        }}
+      >
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={cn("relative", className)}
+          role="region"
+          aria-roledescription="carousel"
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    );
+  },
+);
+Carousel.displayName = "Carousel";
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel();
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
+      <div
+        ref={ref}
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+});
+CarouselContent.displayName = "CarouselContent";
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel();
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+CarouselItem.displayName = "CarouselItem";
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute  h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-left-12 top-1/2 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className,
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  );
+});
+CarouselPrevious.displayName = "CarouselPrevious";
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-right-12 top-1/2 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className,
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  );
+});
+CarouselNext.displayName = "CarouselNext";
+
+export {
+  Carousel,
+  type CarouselApi,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+};


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #178 
- /notices 페이지 맞춤 공고를 사용자가 확인할 수 있어야 한다.

# 어떤 변화가 생겼나요?
- /notices 페이지 맞춤공고 carousel 구현

# 스크린샷(optional)
![캐러셀](https://github.com/S2-P3-T5/Julge/assets/144401634/d7e0dc2b-091b-417c-b01a-4c3f99e28d80)

