### PR TITLE
공통: 공고리스트 - 전체 공고 정렬 구현

### DIFF
--- a/src/apis/notice/index.ts
+++ b/src/apis/notice/index.ts
@@ -92,10 +92,13 @@ export const getNoticesListData = async (
   }
 };
 
-export const getCustomNoticesListData = async (address = "") => {
+export const getCustomNoticesListData = async (address = "", startsAt = "") => {
+  const startsAtGte = startsAt ? `&startsAtGte=${startsAt}` : "";
   try {
     const response = await fetcher.get(
-      apiRouteUtils.NOTICES + `?offset=0&limit=10&address=${address}`,
+      apiRouteUtils.NOTICES +
+        `?offset=0&limit=10&address=${address}` +
+        startsAtGte,
     );
     const result = await response.json();
     return result;

--- a/src/apis/notice/index.ts
+++ b/src/apis/notice/index.ts
@@ -71,11 +71,20 @@ export const putNoticeRegistration = async (
     });
 };
 
-export const getNoticesListData = async (offset = 0) => {
+export const getNoticesListData = async (
+  offset = 0,
+  sort = "",
+  startsAt = "",
+) => {
+  const sortOption = sort ? `&sort=${sort}` : "";
+  const startsAtGte = startsAt ? `&startsAtGte=${startsAt}` : "";
+  const apiURL =
+    apiRouteUtils.NOTICES +
+    `?offset=${offset}&limit=6` +
+    sortOption +
+    startsAtGte;
   try {
-    const response = await fetcher.get(
-      apiRouteUtils.NOTICES + `?offset=${offset}&limit=6`,
-    );
+    const response = await fetcher.get(apiURL);
     const result = await response.json();
     return result;
   } catch (err: any) {

--- a/src/components/notices/NoticeListDropDownMenu.tsx
+++ b/src/components/notices/NoticeListDropDownMenu.tsx
@@ -12,26 +12,35 @@ import { cn } from "@/lib/utils";
 
 const frameworks = [
   {
-    value: "test1",
+    value: "time",
     label: "마감임박순",
   },
   {
-    value: "test2",
+    value: "pay",
     label: "시급많은순",
   },
   {
-    value: "test3",
-    label: "시급적은순",
+    value: "hour",
+    label: "시간적은순",
   },
   {
-    value: "test4",
+    value: "shop",
     label: "가나다순",
   },
 ];
 
-export default function NoticeListDropdownMenu() {
+interface NotcieListDropdownMenuProps {
+  handleOrderBy: (value: string) => void;
+}
+
+export default function NoticeListDropdownMenu({
+  handleOrderBy,
+}: NotcieListDropdownMenuProps) {
   const [open, setOpen] = React.useState(false);
   const [value, setValue] = React.useState("");
+  React.useEffect(() => {
+    handleOrderBy(value);
+  }, [value]);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/src/components/notices/NoticeLists.tsx
+++ b/src/components/notices/NoticeLists.tsx
@@ -31,6 +31,7 @@ function getCurrentDateTime() {
   return rfc3339DateTime;
 }
 
+//TODO : data get 할 시 쿼리 파라미터 옵션 객체로 변경(다음 필터 이슈에서 설정)
 export default function NoticesLists() {
   const user = useContext<any>(UserContext);
   const [page, setPage] = useState(1);
@@ -54,6 +55,7 @@ export default function NoticesLists() {
       );
       const resultCustomNotices: any = await getCustomNoticesListData(
         user?.address,
+        startsAtGte,
       );
       setCustomNoticesList(resultCustomNotices.items);
       setNoticesList(resultAllNotices.items);

--- a/src/components/notices/NoticeLists.tsx
+++ b/src/components/notices/NoticeLists.tsx
@@ -1,13 +1,11 @@
-import { useContext, useEffect, useState } from "react";
-
 import Link from "next/link";
+import { Fragment, useContext, useEffect, useState } from "react";
 
 import { getCustomNoticesListData, getNoticesListData } from "@/apis/notice";
 import NoticeListDropdownMenu from "@/components/notices/NoticeListDropDownMenu";
 import NoticeListPagination from "@/components/notices/NoticeListPagination";
 import NoticeListPopover from "@/components/notices/NoticeListPopover";
 import ShopsNoticesListItem from "@/components/shop/ShopsNoticesListItem";
-
 import {
   Carousel,
   CarouselContent,
@@ -15,9 +13,23 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@/components/ui/carousel";
-
 import { UserContext } from "@/providers/UserProvider";
 import { PAGE_ROUTES } from "@/routes";
+
+function getCurrentDateTime() {
+  const now = new Date();
+
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  const hours = String(now.getHours()).padStart(2, "0");
+  const minutes = String(now.getMinutes() + 1).padStart(2, "0");
+  const seconds = String(now.getSeconds()).padStart(2, "0");
+
+  const rfc3339DateTime = `${year}-${month}-${day}T${hours}:${minutes}:${seconds}Z`;
+
+  return rfc3339DateTime;
+}
 
 export default function NoticesLists() {
   const user = useContext<any>(UserContext);
@@ -26,15 +38,20 @@ export default function NoticesLists() {
   const [options, setOptions] = useState({
     address: [],
     count: 0,
-    hasNext: true,
     limit: 6,
     offset: 0,
   });
   const [customNoticesList, setCustomNoticesList] = useState([]);
+  const [orderBy, setOrderBy] = useState("");
 
   useEffect(() => {
     const getData = async () => {
-      const resultAllNotices: any = await getNoticesListData();
+      const startsAtGte = getCurrentDateTime();
+      const resultAllNotices: any = await getNoticesListData(
+        options.offset,
+        orderBy,
+        startsAtGte,
+      );
       const resultCustomNotices: any = await getCustomNoticesListData(
         user?.address,
       );
@@ -43,7 +60,6 @@ export default function NoticesLists() {
       setOptions({
         address: resultAllNotices.address,
         count: resultAllNotices.count,
-        hasNext: resultAllNotices.hasNext,
         limit: 6,
         offset: resultAllNotices.offset,
       });
@@ -54,14 +70,37 @@ export default function NoticesLists() {
   useEffect(() => {
     const getData = async () => {
       const newOffset = (page - 1) * 6;
-      const resultAllNotices: any = await getNoticesListData(newOffset);
+      const startsAtGte = getCurrentDateTime();
+      const resultAllNotices: any = await getNoticesListData(
+        newOffset,
+        orderBy,
+        startsAtGte,
+      );
       setNoticesList(resultAllNotices.items);
     };
     getData();
   }, [page]);
 
+  useEffect(() => {
+    const startsAtGte = getCurrentDateTime();
+    const getData = async () => {
+      const resultAllNotices: any = await getNoticesListData(
+        options.offset,
+        orderBy,
+        startsAtGte,
+      );
+      setNoticesList(resultAllNotices.items);
+      setPage(1);
+    };
+    getData();
+  }, [orderBy]);
+
   const handlePage = (num: number) => {
     setPage(num);
+  };
+
+  const handleOrderBy = (value: string) => {
+    setOrderBy(value);
   };
 
   return (
@@ -79,10 +118,17 @@ export default function NoticesLists() {
                     <>
                       <CarouselItem className="basis-100">
                         <li key={data.item.id}>
-                          <ShopsNoticesListItem
-                            item={data.item}
-                            shopData={data.item.shop.item}
-                          />
+                          <Link
+                            href={PAGE_ROUTES.parseNotciesApplyURL(
+                              data.item.shop.item.id,
+                              data.item.id,
+                            )}
+                          >
+                            <ShopsNoticesListItem
+                              item={data.item}
+                              shopData={data.item.shop.item}
+                            />
+                          </Link>
                         </li>
                       </CarouselItem>
                     </>
@@ -100,26 +146,24 @@ export default function NoticesLists() {
           <span className="text-[2rem] font-bold tablet:text-[2.8rem]">
             전체 공고
           </span>
-          <NoticeListDropdownMenu />
+          <NoticeListDropdownMenu handleOrderBy={handleOrderBy} />
           <NoticeListPopover />
           <div className="flex w-[35.1rem] flex-wrap justify-between gap-x-[0.9rem] gap-y-[1.6rem] tablet:w-[67.8rem] tablet:gap-y-[3.2rem] desktop:w-[96.4rem]">
             {noticesList &&
               noticesList.map((data: any) => (
-                <>
+                <li key={data.item.id}>
                   <Link
                     href={PAGE_ROUTES.parseNotciesApplyURL(
                       data.item.shop.item.id,
                       data.item.id,
                     )}
                   >
-                    <li key={data.item.id}>
-                      <ShopsNoticesListItem
-                        item={data.item}
-                        shopData={data.item.shop.item}
-                      />
-                    </li>
+                    <ShopsNoticesListItem
+                      item={data.item}
+                      shopData={data.item.shop.item}
+                    />
                   </Link>
-                </>
+                </li>
               ))}
           </div>
         </ul>


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #180 
- 전체 공고에서 사용자가 원하는 기준으로 정렬할 수 있어야 한다.

# 어떤 변화가 생겼나요?
- 공고목록을 마감임박순, 시급많은순, 시간적은순, 가나다순으로 정렬할 수 있다.
- 현재 시간을 초과한 공고는 표시하지 않는다.

# 스크린샷(optional)
![sort](https://github.com/S2-P3-T5/Julge/assets/144401634/9859929c-d5a6-492d-916c-74ac0397b270)
