### PR TITLE
유저-( 공고 상세 페이지 ): 공고상세페이지(로그인상태)에 접근할 때 유저의 타입이 employer이면 가게 정보 상세페이지로 이동시키는 기능 구현 + employeeLayout 반응형 디자인 구현

### DIFF
--- a/src/components/common/EmployeeHeader.tsx
+++ b/src/components/common/EmployeeHeader.tsx
@@ -24,10 +24,10 @@ export default function EmployeeHeader() {
           priority
         />
       </Link>
-      <div className="order-3 flex-1">
+      <div className="order-3 flex-1 tablet:order-2">
         <SearchBar />
       </div>
-      <div className="order-2 flex items-center gap-[4px] text-[1.4rem] font-bold">
+      <div className="order-2 flex items-center gap-[4px] text-[1.4rem] font-bold tablet:order-3">
         {user ? (
           <>
             <Button

--- a/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
@@ -2,15 +2,17 @@ import { useQuery } from "@tanstack/react-query";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 
 import { fetcher } from "@/apis/fetcher";
 import EmployeeLayout from "@/components/common/EmployeeLayout";
+import EmployerLayout from "@/components/common/EmployerLayout";
 import { HighHourlyWageBadge } from "@/components/noticeDetail/Badge";
 import { ApplyNoticeButton } from "@/components/noticeDetail/Buttons";
 import { useTimeCalculate } from "@/components/noticeDetail/Hooks";
 import NoticeApplyItem from "@/components/noticeDetail/NoticeApplyItem";
 import { getAccessTokenInStorage } from "@/helpers/auth";
+import { UserContext } from "@/providers/UserProvider";
 import { apiRouteUtils, PAGE_ROUTES } from "@/routes";
 
 function NoticeDetailApply() {
@@ -18,6 +20,7 @@ function NoticeDetailApply() {
     { id: string; data: any }[]
   >([]);
   const router = useRouter();
+  const user = useContext(UserContext);
   const { shopId, noticeId } = router.query;
   const normalizedShopId = String(shopId);
   const normalizedNoticeId = String(noticeId);
@@ -112,9 +115,13 @@ function NoticeDetailApply() {
     const notices = localStorage.getItem("recentNotices");
     if (notices) storedRecentNotices = JSON.parse(notices);
   }
+  let LayoutComponent = EmployeeLayout; // 기본값으로 EmployeeLayout을 사용
+  if (user?.type === "employer") {
+    LayoutComponent = EmployerLayout; // user의 type이 'employer'일 때는 EmployerLayout을 사용
+  }
 
   return (
-    <EmployeeLayout>
+    <LayoutComponent>
       <div className="flex w-full flex-col items-center justify-center tablet:w-[74.4rem] desktop:w-[144rem]">
         <div className="flex w-full flex-col items-start gap-[1.2rem] bg-[#fafafa] px-[1.2rem] py-[4rem] tablet:w-full tablet:px-[3.2rem] tablet:py-[6rem] desktop:px-[23.8rem]">
           <div className="flex w-full flex-col gap-[1.6rem] tablet:w-full">
@@ -222,7 +229,7 @@ function NoticeDetailApply() {
           </div>
         </div>
       </div>
-    </EmployeeLayout>
+    </LayoutComponent>
   );
 }
 

--- a/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
@@ -6,7 +6,6 @@ import React, { useContext, useEffect, useState } from "react";
 
 import { fetcher } from "@/apis/fetcher";
 import EmployeeLayout from "@/components/common/EmployeeLayout";
-import EmployerLayout from "@/components/common/EmployerLayout";
 import { HighHourlyWageBadge } from "@/components/noticeDetail/Badge";
 import { ApplyNoticeButton } from "@/components/noticeDetail/Buttons";
 import { useTimeCalculate } from "@/components/noticeDetail/Hooks";
@@ -24,6 +23,13 @@ function NoticeDetailApply() {
   const { shopId, noticeId } = router.query;
   const normalizedShopId = String(shopId);
   const normalizedNoticeId = String(noticeId);
+
+  useEffect(() => {
+    if (user?.type === "employer") {
+      router.push("/shops");
+    }
+  }, [user, router]);
+
   const { data } = useQuery<any>({
     queryKey: ["notices", noticeId],
     queryFn: async () => {
@@ -115,13 +121,9 @@ function NoticeDetailApply() {
     const notices = localStorage.getItem("recentNotices");
     if (notices) storedRecentNotices = JSON.parse(notices);
   }
-  let LayoutComponent = EmployeeLayout; // 기본값으로 EmployeeLayout을 사용
-  if (user?.type === "employer") {
-    LayoutComponent = EmployerLayout; // user의 type이 'employer'일 때는 EmployerLayout을 사용
-  }
 
   return (
-    <LayoutComponent>
+    <EmployeeLayout>
       <div className="flex w-full flex-col items-center justify-center tablet:w-[74.4rem] desktop:w-[144rem]">
         <div className="flex w-full flex-col items-start gap-[1.2rem] bg-[#fafafa] px-[1.2rem] py-[4rem] tablet:w-full tablet:px-[3.2rem] tablet:py-[6rem] desktop:px-[23.8rem]">
           <div className="flex w-full flex-col gap-[1.6rem] tablet:w-full">
@@ -229,7 +231,7 @@ function NoticeDetailApply() {
           </div>
         </div>
       </div>
-    </LayoutComponent>
+    </EmployeeLayout>
   );
 }
 


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: 공고상세페이지(로그인상태)에 접근할 때 유저의 타입이 employer이면 페이지 접근을 막아야 함
- employeeLayout의 반응형 디자인 구현이 필요

# 어떤 변화가 생겼나요?

- 공고상세페이지(로그인상태)에 접근할 때 유저의 타입이 employer이면 가게 정보 상세페이지로 이동시키는 기능 구현
- employeeLayout의 반응형 디자인 구현

# 스크린샷(optional)
