### PR TITLE
알바님 - 공고 상세 페이지(로그인 상태): '신청하기' 버튼을 누르면 프로필 등록이 되어있지 않으면 alert 창이 나타나고 '확인' 버튼을 누르면 프로필 등록 페이지로 이동하는 기능 구현

### DIFF
--- a/src/components/noticeDetail/Buttons.tsx
+++ b/src/components/noticeDetail/Buttons.tsx
@@ -23,9 +23,12 @@ export const EditNoticeButton: React.FC<EditNoticeButtonProps> = ({
   );
 };
 
-export const ApplyNoticeButton = () => {
+export const ApplyNoticeButton = ({ handleApply }: any) => {
   return (
-    <Button className="h-[3.8rem] w-full rounded-[0.6rem] border-[0.1rem] border-primary bg-primary px-[2rem] py-[1rem] tablet:h-[4.8rem]">
+    <Button
+      onClick={handleApply}
+      className="h-[3.8rem] w-full rounded-[0.6rem] border-[0.1rem] border-primary bg-primary px-[2rem] py-[1rem] tablet:h-[4.8rem]"
+    >
       <span className="text-center text-[1.4rem] font-bold not-italic leading-normal text-white tablet:text-[1.6rem]">
         신청하기
       </span>

--- a/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
@@ -12,6 +12,7 @@ import { useTimeCalculate } from "@/components/noticeDetail/Hooks";
 import NoticeApplyItem from "@/components/noticeDetail/NoticeApplyItem";
 import { getAccessTokenInStorage } from "@/helpers/auth";
 import { UserContext } from "@/providers/UserProvider";
+import { useUserQuery } from "@/queries/user";
 import { apiRouteUtils, PAGE_ROUTES } from "@/routes";
 
 function NoticeDetailApply() {
@@ -23,6 +24,25 @@ function NoticeDetailApply() {
   const { shopId, noticeId } = router.query;
   const normalizedShopId = String(shopId);
   const normalizedNoticeId = String(noticeId);
+
+  const { userProfile }: any = useUserQuery();
+
+  const profile =
+    userProfile && userProfile.name && userProfile.phone && userProfile.address
+      ? {
+          name: userProfile.name,
+          phone: userProfile.phone,
+          address: userProfile.address,
+        }
+      : undefined;
+
+  const handleApply = () => {
+    if (!profile) {
+      alert("내 프로필을 먼저 등록해 주세요.");
+      router.push("/my");
+    } else {
+    }
+  };
 
   useEffect(() => {
     if (user?.type === "employer") {
@@ -195,7 +215,7 @@ function NoticeDetailApply() {
                     {shopOriginalData?.description}
                   </span>
                 </div>
-                <ApplyNoticeButton />
+                <ApplyNoticeButton handleApply={handleApply} />
               </div>
             </div>
             <div className="flex h-[15.3rem] w-full flex-col items-start gap-[0.8rem] rounded-[1.2rem] bg-gray-10 p-[2rem] tablet:h-[14.8rem]">


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: 공고에 신청할 때 프로필 등록이 필요하기때문에, 신청 시 등록된 프로필 정보가 없을 경우 프로필 등록 페이지로 이동시키는 기능 필요

# 어떤 변화가 생겼나요?

- 공고에 신청할 때 프로필 등록이 필요하기때문에, 신청 시 등록된 프로필 정보가 없을 경우 프로필 등록 페이지로 이동시키는 기능 필요

# 스크린샷(optional)

https://github.com/S2-P3-T5/Julge/assets/129366303/63d95f6c-673c-46a5-bb75-c8bb7ca4491d

