### PR TITLE
내프로필: 프로필 등록 폼에 성별을 소개로 변경, 프로필 카드에 소개 추가

### DIFF
--- a/src/components/my/ProfileCard.tsx
+++ b/src/components/my/ProfileCard.tsx
@@ -11,6 +11,7 @@ interface Props {
     name: string;
     phone: string;
     address: string;
+    bio?: string;
   };
 }
 
@@ -42,6 +43,9 @@ export default function ProfileCard({ profile }: Props) {
           />
           선호 지역: {profile.address}
         </div>
+        <p className="mt-[16px] min-h-[24px] w-full text-wrap text-[1.4rem] text-black">
+          {profile.bio}
+        </p>
       </CardContent>
       <Button
         variant="link"

--- a/src/components/my/RegisterForm.tsx
+++ b/src/components/my/RegisterForm.tsx
@@ -1,5 +1,4 @@
 import useMyRegisterForm from "@/components/my/useMyRegisterForm";
-import { CheckRadioGroupItem } from "@/components/signup/CheckRadioGroupItem";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -10,7 +9,6 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { RadioGroup } from "@/components/ui/radio-group";
 import {
   Select,
   SelectContent,
@@ -18,7 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { cn } from "@/lib/utils";
+import { Textarea } from "@/components/ui/textarea";
 
 export default function RegisterForm() {
   const { form, onSubmit, rules, handlers } = useMyRegisterForm();
@@ -130,36 +128,13 @@ export default function RegisterForm() {
             rules={rules.bio}
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-[1.6rem]">성별</FormLabel>
+                <FormLabel className="text-[1.6rem]">소개</FormLabel>
                 <FormControl>
-                  <RadioGroup
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                    className="flex gap-[1.6rem]"
-                  >
-                    <FormItem
-                      className={cn(
-                        "flex items-center justify-center gap-[1.2rem] space-y-0 rounded-[3.2rem] border-[0.1rem] border-gray-30 bg-white px-[4.2rem] py-[1.2rem]",
-                        field.value === "male" && "border-primary",
-                      )}
-                    >
-                      <FormControl>
-                        <CheckRadioGroupItem value="male" />
-                      </FormControl>
-                      <FormLabel className="text-[1.4rem]">남성</FormLabel>
-                    </FormItem>
-                    <FormItem
-                      className={cn(
-                        "flex items-center justify-center gap-[1.2rem] space-y-0 rounded-[3.2rem] border-[0.1rem] border-gray-30 bg-white px-[4.2rem] py-[1.2rem]",
-                        field.value === "female" && "border-primary",
-                      )}
-                    >
-                      <FormControl>
-                        <CheckRadioGroupItem value="female" />
-                      </FormControl>
-                      <FormLabel className="text-[1.4rem]">여성</FormLabel>
-                    </FormItem>
-                  </RadioGroup>
+                  <Textarea
+                    placeholder="간단한 소개를 입력해주세요"
+                    className="mt-[8px] h-[156px] resize-none p-[16px] focus-visible:ring-gray-40"
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage className="absolute text-[1.2rem]" />
               </FormItem>

--- a/src/components/my/RegisterForm.tsx
+++ b/src/components/my/RegisterForm.tsx
@@ -132,7 +132,7 @@ export default function RegisterForm() {
                 <FormControl>
                   <Textarea
                     placeholder="간단한 소개를 입력해주세요"
-                    className="mt-[8px] h-[156px] resize-none p-[16px] focus-visible:ring-gray-40"
+                    className="mt-[8px] h-[156px] resize-none rounded-[8px] p-[16px] focus-visible:ring-gray-40"
                     {...field}
                   />
                 </FormControl>

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -17,7 +17,12 @@ export default function My() {
 
   const profile =
     user && user.name && user.phone && user.address
-      ? { name: user.name, phone: user.phone, address: user.address }
+      ? {
+          name: user.name,
+          phone: user.phone,
+          address: user.address,
+          bio: user.bio,
+        }
       : undefined;
 
   return (


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #203 
- 소개를 성별로 잘못 구현했습니다.

# 어떤 변화가 생겼나요?

- 프로필 등록 폼에 성별을 소개로 변경
- 프로필 카드에 소개 추가

# 스크린샷(optional)
<img width="372" alt="스크린샷 2024-02-09 오후 11 15 58" src="https://github.com/S2-P3-T5/Julge/assets/29909393/6e1714ce-b71d-4eec-8af1-dc9caaef8518">
<img width="372" alt="스크린샷 2024-02-09 오후 11 16 13" src="https://github.com/S2-P3-T5/Julge/assets/29909393/ba0d59c7-f6ed-46e3-8d84-ad1c3e4f1743">
