### PR TITLE
사장님 - ( 공고 상세 페이지 ): 신청받은 공고를 신청자 목록에 나오도록 하고 각 신청을 승인, 거절하는 기능 구현

### DIFF
--- a/src/apis/notice/index.ts
+++ b/src/apis/notice/index.ts
@@ -3,11 +3,15 @@ import { HTTPError } from "ky";
 import { fetcher } from "@/apis/fetcher";
 import {
   ApplicationPostRequestBody,
+  ApplicationPutRequestBody,
   NoticesPostRequestBody,
   NoticesPostResponse,
   noticesPostResponseSchema,
 } from "@/apis/notice/schema";
-import { applyPostResponseSchema } from "@/apis/user/schema";
+import {
+  applyPostResponseSchema,
+  applyPutResponseSchema,
+} from "@/apis/user/schema";
 import { getAccessTokenInStorage } from "@/helpers/auth";
 import { apiRouteUtils } from "@/routes";
 
@@ -147,4 +151,39 @@ export const getCustomNoticesListData = async (address = "", startsAt = "") => {
   } catch (err: any) {
     throw err;
   }
+};
+
+export const putNoticeApplication = async (
+  { status }: ApplicationPutRequestBody,
+  shopId: string,
+  noticeId: string,
+  applicationId: string,
+): Promise<any> => {
+  const token = getAccessTokenInStorage();
+  if (!token) {
+    throw new Error("Token not found");
+  }
+
+  return await fetcher
+    .put(
+      apiRouteUtils.parseNoticePutApply(
+        shopId as string,
+        noticeId as string,
+        applicationId as string,
+      ),
+      {
+        json: {
+          status,
+        },
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    )
+    .json()
+    .then(applyPutResponseSchema.parse)
+    .then((res) => res.item)
+    .catch((err: HTTPError) => {
+      throw err;
+    });
 };

--- a/src/apis/notice/schema.ts
+++ b/src/apis/notice/schema.ts
@@ -34,6 +34,10 @@ export type ApplicationPostRequestBody = {
   bio?: string;
 };
 
+export type ApplicationPutRequestBody = {
+  status: string;
+};
+
 export const noticesGetResponseSchema = z
   .object({
     items: z.array(

--- a/src/apis/user/schema.ts
+++ b/src/apis/user/schema.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 
-import { linksSchema, shopSchema, userSchema } from "@/apis/schema";
+import {
+  applicationSchema,
+  linksSchema,
+  shopSchema,
+  userSchema,
+} from "@/apis/schema";
 import { Address } from "@/types/user";
 
 export const requiredUserSchema = userSchema.pick({
@@ -14,6 +19,16 @@ export const requiredApplyUserSchema = userSchema.pick({
   name: true,
   phone: true,
 });
+
+export const requiredApplyStatusSchema = applicationSchema.pick({
+  status: true,
+});
+
+export const applyPutResponseSchema = z
+  .object({
+    item: requiredApplyStatusSchema,
+  })
+  .merge(linksSchema);
 
 export const applyPostResponseSchema = z
   .object({

--- a/src/components/noticeDetail/ApplicationList.tsx
+++ b/src/components/noticeDetail/ApplicationList.tsx
@@ -5,7 +5,7 @@ import { apiRouteUtils } from "@/routes";
 
 function ApplicationList(shopId: string, noticeId: string, offset: number) {
   const { data } = useQuery<any>({
-    queryKey: ["noticeApply", offset],
+    queryKey: ["noticeApply", shopId, noticeId],
     queryFn: async () => {
       const response = await fetcher.get(
         apiRouteUtils.parseShopNoticeApplications(shopId, noticeId, offset),

--- a/src/components/noticeDetail/ApproveDialog.tsx
+++ b/src/components/noticeDetail/ApproveDialog.tsx
@@ -15,14 +15,10 @@ import {
 } from "@/components/ui/alert-dialog";
 
 interface ApproveDialogProps {
-  applicationId: string | undefined;
-  handleApprove: (applicationId: string) => void;
+  handleApprove: () => void;
 }
 
-const ApproveDialog: React.FC<ApproveDialogProps> = ({
-  applicationId,
-  handleApprove,
-}) => {
+const ApproveDialog: React.FC<ApproveDialogProps> = ({ handleApprove }) => {
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
@@ -63,9 +59,7 @@ const ApproveDialog: React.FC<ApproveDialogProps> = ({
             </span>
           </AlertDialogCancel>
           <AlertDialogAction
-            onClick={() =>
-              applicationId !== undefined && handleApprove(applicationId)
-            }
+            onClick={() => handleApprove()}
             className="h-[3.8rem] w-[8rem] rounded-[0.6rem] border-[0.1rem] border-primary bg-primary px-[2rem] py-[1rem]"
           >
             <span className="text-[1.4rem] font-bold not-italic leading-normal text-white">

--- a/src/components/noticeDetail/ApproveDialog.tsx
+++ b/src/components/noticeDetail/ApproveDialog.tsx
@@ -15,8 +15,8 @@ import {
 } from "@/components/ui/alert-dialog";
 
 interface ApproveDialogProps {
-  applicationId: number | undefined;
-  handleApprove: (applicationId: number) => void;
+  applicationId: string | undefined;
+  handleApprove: (applicationId: string) => void;
 }
 
 const ApproveDialog: React.FC<ApproveDialogProps> = ({

--- a/src/components/noticeDetail/Pagination.tsx
+++ b/src/components/noticeDetail/Pagination.tsx
@@ -24,18 +24,18 @@ function ApplyListPagination({
   setOffset,
   nextData,
 }: ApplyListPaginationProps): JSX.Element {
-  const isFirstPage = offset < 1;
+  const isFirstPage = offset / 5 + 1 < 1;
   const isLastPage = !nextData;
 
   const handlePreviousClick = () => {
     if (!isFirstPage) {
-      setOffset(offset - 1);
+      setOffset(offset - 5);
     }
   };
 
   const handleNextClick = () => {
     if (!isLastPage) {
-      setOffset(offset + 1);
+      setOffset(offset + 5);
     }
   };
   return (
@@ -43,7 +43,7 @@ function ApplyListPagination({
       <PaginationContent>
         <PaginationItem>
           <PaginationPrevious
-            href={`${PAGE_ROUTES.parseShopNoticeDetailsURL(shopId, noticeId)}?limit=5&offset=${offset - 1}`}
+            href={`${PAGE_ROUTES.parseShopNoticeDetailsURL(shopId, noticeId)}?limit=5&offset=${offset - 5}`}
             onClick={handlePreviousClick}
             isActive={!isFirstPage}
           />
@@ -52,7 +52,9 @@ function ApplyListPagination({
           <PaginationLink
             href={`${PAGE_ROUTES.parseShopNoticeDetailsURL(shopId, noticeId)}?limit=5&offset=${offset}`}
           >
-            <span className="text-[1.2rem] tablet:text-[1.4rem]">{offset}</span>
+            <span className="text-[1.2rem] tablet:text-[1.4rem]">
+              {offset / 5 + 1}
+            </span>
           </PaginationLink>
         </PaginationItem>
         <PaginationItem>
@@ -60,7 +62,7 @@ function ApplyListPagination({
         </PaginationItem>
         <PaginationItem>
           <PaginationNext
-            href={`${PAGE_ROUTES.parseShopNoticeDetailsURL(shopId, noticeId)}?limit=5&offset=${offset + 1}`}
+            href={`${PAGE_ROUTES.parseShopNoticeDetailsURL(shopId, noticeId)}?limit=5&offset=${offset + 5}`}
             onClick={handleNextClick}
             isActive={!isLastPage}
           />

--- a/src/components/noticeDetail/Pagination.tsx
+++ b/src/components/noticeDetail/Pagination.tsx
@@ -13,24 +13,44 @@ interface ApplyListPaginationProps {
   offset: number;
   shopId: string;
   noticeId: string;
+  setOffset: (newOffset: number) => void;
+  nextData: boolean;
 }
 
 function ApplyListPagination({
   offset,
   shopId,
   noticeId,
+  setOffset,
+  nextData,
 }: ApplyListPaginationProps): JSX.Element {
+  const isFirstPage = offset < 1;
+  const isLastPage = !nextData;
+
+  const handlePreviousClick = () => {
+    if (!isFirstPage) {
+      setOffset(offset - 1);
+    }
+  };
+
+  const handleNextClick = () => {
+    if (!isLastPage) {
+      setOffset(offset + 1);
+    }
+  };
   return (
     <Pagination>
       <PaginationContent>
         <PaginationItem>
           <PaginationPrevious
-            href={`${PAGE_ROUTES.parseShopNoticeDetailsURL(shopId, noticeId)}?limit=6&offset=${offset - 1}`}
+            href={`${PAGE_ROUTES.parseShopNoticeDetailsURL(shopId, noticeId)}?limit=5&offset=${offset - 1}`}
+            onClick={handlePreviousClick}
+            isActive={!isFirstPage}
           />
         </PaginationItem>
         <PaginationItem>
           <PaginationLink
-            href={`${PAGE_ROUTES.parseShopNoticeDetailsURL(shopId, noticeId)}?limit=6&offset=${offset}`}
+            href={`${PAGE_ROUTES.parseShopNoticeDetailsURL(shopId, noticeId)}?limit=5&offset=${offset}`}
           >
             <span className="text-[1.2rem] tablet:text-[1.4rem]">{offset}</span>
           </PaginationLink>
@@ -40,7 +60,9 @@ function ApplyListPagination({
         </PaginationItem>
         <PaginationItem>
           <PaginationNext
-            href={`${PAGE_ROUTES.parseShopNoticeDetailsURL(shopId, noticeId)}?limit=6&offset=${offset + 1}`}
+            href={`${PAGE_ROUTES.parseShopNoticeDetailsURL(shopId, noticeId)}?limit=5&offset=${offset + 1}`}
+            onClick={handleNextClick}
+            isActive={!isLastPage}
           />
         </PaginationItem>
       </PaginationContent>

--- a/src/components/noticeDetail/RejectDialog.tsx
+++ b/src/components/noticeDetail/RejectDialog.tsx
@@ -15,14 +15,10 @@ import {
 } from "@/components/ui/alert-dialog";
 
 interface RejectDialogProps {
-  applicationId: string | undefined;
-  handleReject: (applicationId: string) => void;
+  handleReject: () => void;
 }
 
-const RejectDialog: React.FC<RejectDialogProps> = ({
-  applicationId,
-  handleReject,
-}) => {
+const RejectDialog: React.FC<RejectDialogProps> = ({ handleReject }) => {
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
@@ -63,9 +59,7 @@ const RejectDialog: React.FC<RejectDialogProps> = ({
             </span>
           </AlertDialogCancel>
           <AlertDialogAction
-            onClick={() =>
-              applicationId !== undefined && handleReject(applicationId)
-            }
+            onClick={() => handleReject()}
             className="h-[3.8rem] w-[8rem] rounded-[0.6rem] border-[0.1rem] border-primary bg-primary px-[2rem] py-[1rem]"
           >
             <span className="text-[1.4rem] font-bold not-italic leading-normal text-white">

--- a/src/components/noticeDetail/RejectDialog.tsx
+++ b/src/components/noticeDetail/RejectDialog.tsx
@@ -15,8 +15,8 @@ import {
 } from "@/components/ui/alert-dialog";
 
 interface RejectDialogProps {
-  applicationId: number | undefined;
-  handleReject: (applicationId: number) => void;
+  applicationId: string | undefined;
+  handleReject: (applicationId: string) => void;
 }
 
 const RejectDialog: React.FC<RejectDialogProps> = ({

--- a/src/components/notices/NoticeListDropDownMenu.tsx
+++ b/src/components/notices/NoticeListDropDownMenu.tsx
@@ -40,7 +40,7 @@ export default function NoticeListDropdownMenu({
   const [value, setValue] = React.useState("");
   React.useEffect(() => {
     handleSort(value);
-  }, [handleSort, value]);
+  }, [value]);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/src/components/notices/NoticeListDropDownMenu.tsx
+++ b/src/components/notices/NoticeListDropDownMenu.tsx
@@ -40,7 +40,7 @@ export default function NoticeListDropdownMenu({
   const [value, setValue] = React.useState("");
   React.useEffect(() => {
     handleSort(value);
-  }, [value]);
+  }, [handleSort, value]);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/src/components/notices/NoticeLists.tsx
+++ b/src/components/notices/NoticeLists.tsx
@@ -57,7 +57,7 @@ export default function NoticesLists() {
       setCount(resultAllNotices.count);
     };
     getData();
-  }, []);
+  }, [user?.address]);
 
   useEffect(() => {
     const getData = async () => {
@@ -74,7 +74,7 @@ export default function NoticesLists() {
       setNoticesList(resultAllNotices.items);
     };
     getData();
-  }, [page]);
+  }, [options, page]);
 
   useEffect(() => {
     const startsAtGte = getCurrentDateTime();
@@ -97,7 +97,7 @@ export default function NoticesLists() {
     } else {
       setOptions({ ...options, keyword: "" });
     }
-  }, [search]);
+  }, [options, search]);
 
   const handlePage = (num: number) => {
     setPage(num);

--- a/src/components/notices/NoticeLists.tsx
+++ b/src/components/notices/NoticeLists.tsx
@@ -97,7 +97,7 @@ export default function NoticesLists() {
     } else {
       setOptions({ ...options, keyword: "" });
     }
-  }, [options, search]);
+  }, [search]);
 
   const handlePage = (num: number) => {
     setPage(num);

--- a/src/components/shop/ShopsNoticesList.tsx
+++ b/src/components/shop/ShopsNoticesList.tsx
@@ -42,6 +42,7 @@ export default function ShopsNoticesList({
   const [newNoticesListData, setNewNoticesListData] = useState(noticesListData);
   const [itemList, setitemList] = useState(newNoticesListData.items);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleScroll = () => {
     if (
       window.innerHeight + document.documentElement.scrollTop ===
@@ -69,7 +70,7 @@ export default function ShopsNoticesList({
     return () => {
       window.removeEventListener("scroll", handleScroll);
     };
-  }, []);
+  }, [handleScroll]);
 
   return (
     <div>

--- a/src/pages/shops/[shopId]/index.tsx
+++ b/src/pages/shops/[shopId]/index.tsx
@@ -83,7 +83,7 @@ export default function Shop() {
       };
       getUserData();
     }
-  }, [user]);
+  }, [router, shopId, user]);
 
   useEffect(() => {
     if (typeof shopId === "string") {

--- a/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
@@ -58,6 +58,13 @@ function NoticeDetailApply() {
     }
   }, [user, router]);
 
+  useEffect(() => {
+    if (!getAccessTokenInStorage()) {
+      router.push(PAGE_ROUTES.SIGNIN);
+      return;
+    }
+  }, [router, user]);
+
   const { data } = useQuery<any>({
     queryKey: ["notices", noticeId],
     queryFn: async () => {

--- a/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
@@ -13,7 +13,6 @@ import { useTimeCalculate } from "@/components/noticeDetail/Hooks";
 import NoticeApplyItem from "@/components/noticeDetail/NoticeApplyItem";
 import { getAccessTokenInStorage } from "@/helpers/auth";
 import { useUserQuery } from "@/queries/user";
-// import { UserContext } from "@/providers/UserProvider";
 import { apiRouteUtils, PAGE_ROUTES } from "@/routes";
 
 function NoticeDetailApply() {
@@ -21,7 +20,6 @@ function NoticeDetailApply() {
     { id: string; data: any }[]
   >([]);
   const router = useRouter();
-  // const user = useContext(UserContext);
   const { shopId, noticeId } = router.query;
   const normalizedShopId = String(shopId);
   const normalizedNoticeId = String(noticeId);

--- a/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { fetcher } from "@/apis/fetcher";
 import { postNoticeApplication } from "@/apis/notice";
@@ -12,7 +12,8 @@ import { ApplyNoticeButton } from "@/components/noticeDetail/Buttons";
 import { useTimeCalculate } from "@/components/noticeDetail/Hooks";
 import NoticeApplyItem from "@/components/noticeDetail/NoticeApplyItem";
 import { getAccessTokenInStorage } from "@/helpers/auth";
-import { UserContext } from "@/providers/UserProvider";
+import { useUserQuery } from "@/queries/user";
+// import { UserContext } from "@/providers/UserProvider";
 import { apiRouteUtils, PAGE_ROUTES } from "@/routes";
 
 function NoticeDetailApply() {
@@ -20,10 +21,16 @@ function NoticeDetailApply() {
     { id: string; data: any }[]
   >([]);
   const router = useRouter();
-  const user = useContext(UserContext);
+  // const user = useContext(UserContext);
   const { shopId, noticeId } = router.query;
   const normalizedShopId = String(shopId);
   const normalizedNoticeId = String(noticeId);
+
+  const { user } = useUserQuery();
+
+  useEffect(() => {
+    if (!user?.id) router.push(PAGE_ROUTES.SIGNIN);
+  }, [user?.id, router]);
 
   const profile =
     user && user.name && user.phone && user.address
@@ -34,6 +41,7 @@ function NoticeDetailApply() {
           bio: user.bio,
         }
       : undefined;
+
   const handleApply = async () => {
     if (!profile) {
       alert("내 프로필을 먼저 등록해 주세요.");

--- a/src/pages/shops/[shopId]/notices/[noticeId]/edit/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/edit/index.tsx
@@ -36,7 +36,7 @@ function NoticeEdit() {
       router.push(PAGE_ROUTES.SIGNIN);
       return;
     }
-  }, [user]);
+  }, [router, user]);
 
   return (
     <EmployerLayout>

--- a/src/pages/shops/[shopId]/notices/[noticeId]/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/index.tsx
@@ -22,6 +22,8 @@ import { apiRouteUtils, PAGE_ROUTES } from "@/routes";
 
 function NoticeDetail() {
   const user = useContext(UserContext);
+  const [showApproveBadge, setShowApproveBadge] = useState(true);
+  const [showRejectBadge, setShowRejectBadge] = useState(true);
   const router = useRouter();
   const [offset, setOffset] = useState(0);
   const { shopId, noticeId } = router.query;
@@ -66,7 +68,7 @@ function NoticeDetail() {
 
   useEffect(() => {
     refetch();
-  }, [offset, refetch]);
+  }, [offset, refetch, showApproveBadge, showRejectBadge]);
 
   const shopOriginalData = data?.item?.shop?.item ?? {};
   const shopNoticeData = data?.item ?? {};
@@ -120,6 +122,7 @@ function NoticeDetail() {
         normalizedNoticeId,
         id,
       );
+      setShowApproveBadge(!showApproveBadge);
     } catch (error) {}
   };
 
@@ -131,6 +134,7 @@ function NoticeDetail() {
         normalizedNoticeId,
         id,
       );
+      setShowRejectBadge(!showRejectBadge);
     } catch (error) {}
   };
 
@@ -149,7 +153,7 @@ function NoticeDetail() {
       router.push(PAGE_ROUTES.SIGNIN);
       return;
     }
-  }, [user]);
+  }, [router, user]);
 
   function handleSetOffset(newOffset: number): void {
     throw new Error("Function not implemented.");

--- a/src/pages/shops/[shopId]/notices/register/index.tsx
+++ b/src/pages/shops/[shopId]/notices/register/index.tsx
@@ -32,7 +32,7 @@ function NoticeRegister() {
       router.push(PAGE_ROUTES.SIGNIN);
       return;
     }
-  }, [user]);
+  }, [router, user]);
 
   return (
     <EmployerLayout>

--- a/src/pages/shops/edit/[shopId].tsx
+++ b/src/pages/shops/edit/[shopId].tsx
@@ -40,7 +40,7 @@ export default function ShopEdit() {
       };
       getUserData();
     }
-  }, [user]);
+  }, [router, shopId, user]);
 
   useEffect(() => {
     if (typeof shopId === "string") {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -41,6 +41,11 @@ export const apiRouteUtils = {
     `shops/${shopId}/notices?offset=${options.offset}&limit=${options.limit}`,
   parseNoticeApply: (shopId: string, noticeId: string) =>
     `shops/${shopId}/notices/${noticeId}/applications`,
+  parseNoticePutApply: (
+    shopId: string,
+    noticeId: string,
+    applicationId: string,
+  ) => `shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
 };
 type OptionsType = {
   offset: number;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -36,7 +36,7 @@ export const apiRouteUtils = {
     noticeId: string,
     offset: number,
   ) =>
-    `shops/${shopId}/notices/${noticeId}/applications?limit=6&offset=${offset}`,
+    `shops/${shopId}/notices/${noticeId}/applications?limit=5&offset=${offset}`,
   parseShopNewNoticesURL: (shopId: string, options: OptionsType) =>
     `shops/${shopId}/notices?offset=${options.offset}&limit=${options.limit}`,
   parseNoticeApply: (shopId: string, noticeId: string) =>


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: 사장님 - ( 공고 상세 페이지 ): 신청받은 공고를 신청자 목록에 나오도록 하고 각 신청을 승인, 거절하는 기능 필요

# 어떤 변화가 생겼나요?

- 사장님 - ( 공고 상세 페이지 ): 신청받은 공고를 신청자 목록에 나오도록 하고 각 신청을 승인, 거절하는 기능 구현
- build 과정에서 생긴 의존성 배열 문제들 해결
- 신청하기 페이지에서 프로필 등록 여부를 확인할 때 잘못된 user데이터로 확인하고 있었음. useContext가 아닌 useUserQuery를 사용함

# 스크린샷(optional)

https://github.com/S2-P3-T5/Julge/assets/129366303/57bfba88-8db8-47bb-b976-a72560616de9

