### PR TITLE
공통: /notices 페이지 외 다른 페이지에서 검색 시 검색 안되는 현상 수정 #211

### DIFF
--- a/src/components/notices/NoticeLists.tsx
+++ b/src/components/notices/NoticeLists.tsx
@@ -42,12 +42,13 @@ export default function NoticesLists() {
     address: [],
     startsAtGte: "",
     hourlyPayGte: 0,
-    keyword: "",
+    keyword: search ? (search as string) : "",
   });
   useEffect(() => {
     const getData = async () => {
       const startsAtGte = getCurrentDateTime();
       const resultAllNotices: any = await getNoticesListData({
+        ...options,
         startsAtGte: startsAtGte,
       });
       const resultCustomNotices: any = await getCustomNoticesListData(
@@ -60,7 +61,7 @@ export default function NoticesLists() {
       setIsLoading(false);
     };
     getData();
-  }, [user?.address]);
+  }, []);
 
   useEffect(() => {
     const getData = async () => {
@@ -77,7 +78,7 @@ export default function NoticesLists() {
       setNoticesList(resultAllNotices.items);
     };
     getData();
-  }, [options, page]);
+  }, [page]);
 
   useEffect(() => {
     const startsAtGte = getCurrentDateTime();
@@ -90,11 +91,13 @@ export default function NoticesLists() {
       setNoticesList(resultAllNotices.items);
       setCount(resultAllNotices.count);
       setPage(1);
+      setIsLoading(false);
     };
     getData();
   }, [options]);
 
   useEffect(() => {
+    setIsLoading(true);
     if (search) {
       setOptions({ ...options, keyword: search as string });
     } else {
@@ -125,8 +128,8 @@ export default function NoticesLists() {
             <span className="text-[2rem] font-bold tablet:text-[2.8rem]">
               {options.keyword ? (
                 <>
-                  <span className="text-primary">{options.keyword}</span>에 대한
-                  공고 목록
+                  <span className="text-primary">{options.keyword}</span>에 대한{" "}
+                  {count}개의 공고
                 </>
               ) : (
                 "전체 공고"


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #211
- /notices 페이지 외 다른페이지에서 가게 검색 시 결과가 정상적으로 출력되지 않음

# 어떤 변화가 생겼나요?
- 검색 결과 정상 출력

# 스크린샷(optional)
![검색 수정](https://github.com/S2-P3-T5/Julge/assets/144401634/7a1fceba-1ccd-47f5-8533-8d021b55e50a)
