### PR TITLE
알바님 - 공고 상세 페이지(로그인 상태): 이미 신청한 공고에서 신청 취소되면서 '취소하기' 버튼이 '신청하기' 버튼으로 바뀌는 기능 구현 + 신청 취소 모달창 + 신청 시 프로필 없을 때 나오는 모달창 구현

### DIFF
--- a/src/components/noticeApply/CancelDialog.tsx
+++ b/src/components/noticeApply/CancelDialog.tsx
@@ -1,0 +1,75 @@
+import Image from "next/image";
+import React from "react";
+
+import { CancelApplyButton } from "@/components/noticeDetail/Buttons";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+
+interface CancelDialogProps {
+  handleCancel: () => void;
+}
+
+const CancelDialog: React.FC<CancelDialogProps> = ({ handleCancel }) => {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <CancelApplyButton />
+      </AlertDialogTrigger>
+      <AlertDialogContent className="h-[18.4rem] w-[29.8rem] rounded-[1.2rem] border-[0.1rem] p-[2.4rem]">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center justify-center">
+            <div className="relative h-[2.4rem] w-[2.4rem]">
+              <Image
+                className="z-0"
+                src="/icons/approve_notification.svg"
+                layout="fill"
+                objectFit="contain"
+                alt="신청취소모달창이미지"
+              />
+              <Image
+                className="z-1"
+                src="/icons/check.svg"
+                layout="fill"
+                objectFit="contain"
+                alt="체크이미지"
+              />
+            </div>
+          </AlertDialogTitle>
+        </AlertDialogHeader>
+        <div className="flex items-center justify-center">
+          <AlertDialogDescription>
+            <span className="text-[1.6rem] font-normal not-italic leading-[2.6rem] text-black">
+              신청을 취소하시겠어요?
+            </span>
+          </AlertDialogDescription>
+        </div>
+        <AlertDialogFooter className="flex flex-row items-center justify-center gap-[0.8rem]">
+          <AlertDialogCancel className="mt-0 h-[3.8rem] w-[8rem] rounded-[0.6rem] border-[0.1rem] border-primary px-[2rem] py-[1rem]">
+            <span className="text-[1.4rem] font-bold not-italic leading-normal text-primary">
+              아니오
+            </span>
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => handleCancel()}
+            className="h-[3.8rem] w-[8rem] rounded-[0.6rem] border-[0.1rem] border-primary bg-primary px-[2rem] py-[1rem]"
+          >
+            <span className="text-[1.4rem] font-bold not-italic leading-normal text-white">
+              취소하기
+            </span>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default CancelDialog;

--- a/src/components/noticeApply/ProfileRegistDialog.tsx
+++ b/src/components/noticeApply/ProfileRegistDialog.tsx
@@ -1,0 +1,91 @@
+import Image from "next/image";
+import React, { useState } from "react";
+
+import { ApplyNoticeButton } from "@/components/noticeDetail/Buttons";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+
+interface ProfileRegistDialogProps {
+  handleApply: () => void;
+  profile:
+    | { name: string; phone: string; address: string; bio: string | undefined }
+    | undefined;
+  pagingProfileRegist: () => void;
+}
+
+const ProfileRegistDialog: React.FC<ProfileRegistDialogProps> = ({
+  handleApply,
+  profile,
+  pagingProfileRegist,
+}) => {
+  const [showModal, setShowModal] = useState(false);
+
+  const handleClick = () => {
+    if (!profile) {
+      setShowModal(true);
+    } else {
+      handleApply();
+    }
+  };
+  return (
+    <>
+      {!showModal && <ApplyNoticeButton onClick={handleClick} />}
+      {showModal && (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <ApplyNoticeButton />
+          </AlertDialogTrigger>
+          <AlertDialogContent className="h-[18.4rem] w-[29.8rem] rounded-[1.2rem] border-[0.1rem] p-[2.4rem]">
+            <AlertDialogHeader>
+              <AlertDialogTitle className="flex items-center justify-center">
+                <div className="relative h-[2.4rem] w-[2.4rem]">
+                  <Image
+                    className="z-0"
+                    src="/icons/approve_notification.svg"
+                    layout="fill"
+                    objectFit="contain"
+                    alt="프로필등록모달창이미지"
+                  />
+                  <Image
+                    className="z-1"
+                    src="/icons/warning.svg"
+                    layout="fill"
+                    objectFit="contain"
+                    alt="경고이미지"
+                  />
+                </div>
+              </AlertDialogTitle>
+            </AlertDialogHeader>
+            <div className="flex items-center justify-center">
+              <AlertDialogDescription>
+                <span className="text-[1.6rem] font-normal not-italic leading-[2.6rem] text-black">
+                  내 프로필을 먼저 등록해 주세요.
+                </span>
+              </AlertDialogDescription>
+            </div>
+            <AlertDialogFooter className="flex flex-row items-center justify-center gap-[0.8rem]">
+              <AlertDialogAction
+                onClick={() => pagingProfileRegist()}
+                className="h-[3.8rem] w-[8rem] rounded-[0.6rem] border-[0.1rem] border-primary bg-primary px-[2rem] py-[1rem]"
+              >
+                <span className="text-[1.4rem] font-bold not-italic leading-normal text-white">
+                  확인
+                </span>
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </>
+  );
+};
+
+export default ProfileRegistDialog;

--- a/src/components/noticeDetail/ApplicationList.tsx
+++ b/src/components/noticeDetail/ApplicationList.tsx
@@ -3,12 +3,12 @@ import { useQuery } from "@tanstack/react-query";
 import { fetcher } from "@/apis/fetcher";
 import { apiRouteUtils } from "@/routes";
 
-function ApplicationList(shopId: string, noticeId: string, offset: number) {
+function ApplicationList(shopId: string, noticeId: string) {
   const { data } = useQuery<any>({
-    queryKey: ["noticeApply", shopId, noticeId],
+    queryKey: ["noticeApplyList", shopId, noticeId],
     queryFn: async () => {
       const response = await fetcher.get(
-        apiRouteUtils.parseShopNoticeApplications(shopId, noticeId, offset),
+        apiRouteUtils.parseNoticeApply(shopId, noticeId),
       );
       if (!response.ok) {
         throw new Error("Network response was not ok");

--- a/src/components/noticeDetail/Buttons.tsx
+++ b/src/components/noticeDetail/Buttons.tsx
@@ -23,14 +23,27 @@ export const EditNoticeButton: React.FC<EditNoticeButtonProps> = ({
   );
 };
 
-export const ApplyNoticeButton = ({ handleApply }: any) => {
+export const ApplyNoticeButton = ({ onClick }: any) => {
   return (
     <Button
-      onClick={handleApply}
+      onClick={onClick}
       className="h-[3.8rem] w-full rounded-[0.6rem] border-[0.1rem] border-primary bg-primary px-[2rem] py-[1rem] tablet:h-[4.8rem]"
     >
       <span className="text-center text-[1.4rem] font-bold not-italic leading-normal text-white tablet:text-[1.6rem]">
         신청하기
+      </span>
+    </Button>
+  );
+};
+
+export const CancelApplyButton = ({ onClick }: any) => {
+  return (
+    <Button
+      onClick={onClick}
+      className="h-[3.8rem] w-full rounded-[0.6rem] border-[0.1rem] border-primary bg-white px-[2rem] py-[1rem] tablet:h-[4.8rem]"
+    >
+      <span className="text-center text-[1.4rem] font-bold not-italic leading-normal text-primary tablet:text-[1.6rem]">
+        취소하기
       </span>
     </Button>
   );

--- a/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/apply/index.tsx
@@ -19,6 +19,7 @@ import { useUserQuery } from "@/queries/user";
 import { apiRouteUtils, PAGE_ROUTES } from "@/routes";
 
 function NoticeDetailApply() {
+  const [mounted, setMounted] = useState<boolean>(false);
   const [recentNotices, setRecentNotices] = useState<
     { id: string; data: any }[]
   >([]);
@@ -30,6 +31,10 @@ function NoticeDetailApply() {
   const { user } = useUserQuery();
   const userProfile = useContext(UserContext);
   const userId = userProfile?.id;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     if (!user?.id) router.push(PAGE_ROUTES.SIGNIN);
@@ -192,123 +197,128 @@ function NoticeDetailApply() {
   }, [refetch, applyStatus, applicationStatus]);
 
   return (
-    <EmployeeLayout>
-      <div className="flex w-full flex-col items-center justify-center tablet:w-[74.4rem] desktop:w-[144rem]">
-        <div className="flex w-full flex-col items-start gap-[1.2rem] bg-[#fafafa] px-[1.2rem] py-[4rem] tablet:w-full tablet:px-[3.2rem] tablet:py-[6rem] desktop:px-[23.8rem]">
-          <div className="flex w-full flex-col gap-[1.6rem] tablet:w-full">
-            <div className="inline-flex flex-col items-start gap-[0.8rem]">
-              <span className="text-[1.4rem] font-bold not-italic leading-normal text-primary tablet:text-[1.6rem]  ">
-                {shopOriginalData?.category}
-              </span>
-              <span className="text-[2rem] font-bold not-italic leading-normal text-black tablet:text-[2.8rem]">
-                {shopOriginalData?.name}
-              </span>
-            </div>
-            <div className="flex w-[35.1rem] flex-col items-start gap-[1.2rem] rounded-[1.2rem] border border-gray-20 bg-white p-[2rem] tablet:w-[68rem] tablet:gap-[1.6rem] tablet:p-[2.4rem] desktop:h-[35.6rem] desktop:w-[96.4rem] desktop:flex-row">
-              <div className="relative flex h-[15.8rem] w-[31.1rem] items-center justify-center tablet:h-[33.2rem] tablet:w-[63.2rem] desktop:h-[30.8rem] desktop:w-[55.4rem]">
-                <Image
-                  src={shopOriginalData?.imageUrl}
-                  layout="fill"
-                  objectFit="contain"
-                  alt="로고이미지"
-                />
-              </div>
-              <div className="flex flex-col items-start gap-[2.4rem] self-stretch">
-                <div className="flex flex-col items-start gap-[0.8rem] self-stretch tablet:gap-[1.2rem]">
-                  <div className="flex flex-col items-start gap-[0.8rem]">
-                    <span className="text-[1.4rem] font-bold not-italic leading-normal text-primary tablet:text-[1.6rem]  ">
-                      시급
-                    </span>
-                    <div className="flex w-full items-center gap-[0.4rem]">
-                      <span className="text-[2.4rem] font-bold not-italic leading-normal tracking-[0.048rem] text-black tablet:text-[2.8rem]">
-                        {shopNoticeData?.hourlyPay}원
-                      </span>
-                      {hourlyPay > originalHourlyPay && (
-                        <HighHourlyWageBadge
-                          className={""}
-                          increasePercentage={0}
-                          {...badgeProps}
-                        />
-                      )}
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-[0.6rem]">
-                    <div className="relative flex h-[1.6rem] w-[1.6rem] items-center justify-center">
-                      <Image
-                        src="/icons/clock.svg"
-                        alt="시간 아이콘"
-                        layout="fill"
-                        objectFit="contain"
-                      />
-                    </div>
-                    <span className="text-[1.4rem] font-normal not-italic leading-[2.2rem] text-gray-50 tablet:text-[1.6rem]">
-                      {startDay} {startTime}:{minute}~{endTime}:{minute}(
-                      {shopOriginalData?.workhour}
-                      시간)
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-[0.6rem]">
-                    <div className="relative flex h-[1.6rem] w-[1.6rem] items-center justify-center">
-                      <Image
-                        src="/icons/point.svg"
-                        alt="장소 아이콘"
-                        layout="fill"
-                        objectFit="contain"
-                      />
-                    </div>
-                    <span className="text-[1.4rem] font-normal not-italic leading-[2.2rem] text-gray-50 tablet:text-[1.6rem]">
-                      {shopOriginalData?.address1} {shopOriginalData?.address2}
-                    </span>
-                  </div>
-                  <span className="text-black-50 h-[6.6rem] scroll-auto text-[1.4rem] font-normal not-italic leading-[2.2rem] tablet:text-[1.6rem]">
-                    {shopOriginalData?.description}
+    mounted && (
+      <>
+        <EmployeeLayout>
+          <div className="flex w-full flex-col items-center justify-center tablet:w-[74.4rem] desktop:w-[144rem]">
+            <div className="flex w-full flex-col items-start gap-[1.2rem] bg-[#fafafa] px-[1.2rem] py-[4rem] tablet:w-full tablet:px-[3.2rem] tablet:py-[6rem] desktop:px-[23.8rem]">
+              <div className="flex w-full flex-col gap-[1.6rem] tablet:w-full">
+                <div className="inline-flex flex-col items-start gap-[0.8rem]">
+                  <span className="text-[1.4rem] font-bold not-italic leading-normal text-primary tablet:text-[1.6rem]  ">
+                    {shopOriginalData?.category}
+                  </span>
+                  <span className="text-[2rem] font-bold not-italic leading-normal text-black tablet:text-[2.8rem]">
+                    {shopOriginalData?.name}
                   </span>
                 </div>
-                {applyStatus === "pending" ? (
-                  <CancelDialog handleCancel={handleCancel} />
-                ) : (
-                  <ProfileRegistDialog
-                    handleApply={handleApply}
-                    profile={profile}
-                    pagingProfileRegist={pagingProfileRegist}
-                  />
-                )}
+                <div className="flex w-[35.1rem] flex-col items-start gap-[1.2rem] rounded-[1.2rem] border border-gray-20 bg-white p-[2rem] tablet:w-[68rem] tablet:gap-[1.6rem] tablet:p-[2.4rem] desktop:h-[35.6rem] desktop:w-[96.4rem] desktop:flex-row">
+                  <div className="relative flex h-[15.8rem] w-[31.1rem] items-center justify-center tablet:h-[33.2rem] tablet:w-[63.2rem] desktop:h-[30.8rem] desktop:w-[55.4rem]">
+                    <Image
+                      src={shopOriginalData?.imageUrl}
+                      layout="fill"
+                      objectFit="contain"
+                      alt="로고이미지"
+                    />
+                  </div>
+                  <div className="flex flex-col items-start gap-[2.4rem] self-stretch">
+                    <div className="flex flex-col items-start gap-[0.8rem] self-stretch tablet:gap-[1.2rem]">
+                      <div className="flex flex-col items-start gap-[0.8rem]">
+                        <span className="text-[1.4rem] font-bold not-italic leading-normal text-primary tablet:text-[1.6rem]  ">
+                          시급
+                        </span>
+                        <div className="flex w-full items-center gap-[0.4rem]">
+                          <span className="text-[2.4rem] font-bold not-italic leading-normal tracking-[0.048rem] text-black tablet:text-[2.8rem]">
+                            {shopNoticeData?.hourlyPay}원
+                          </span>
+                          {hourlyPay > originalHourlyPay && (
+                            <HighHourlyWageBadge
+                              className={""}
+                              increasePercentage={0}
+                              {...badgeProps}
+                            />
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-[0.6rem]">
+                        <div className="relative flex h-[1.6rem] w-[1.6rem] items-center justify-center">
+                          <Image
+                            src="/icons/clock.svg"
+                            alt="시간 아이콘"
+                            layout="fill"
+                            objectFit="contain"
+                          />
+                        </div>
+                        <span className="text-[1.4rem] font-normal not-italic leading-[2.2rem] text-gray-50 tablet:text-[1.6rem]">
+                          {startDay} {startTime}:{minute}~{endTime}:{minute}(
+                          {shopOriginalData?.workhour}
+                          시간)
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-[0.6rem]">
+                        <div className="relative flex h-[1.6rem] w-[1.6rem] items-center justify-center">
+                          <Image
+                            src="/icons/point.svg"
+                            alt="장소 아이콘"
+                            layout="fill"
+                            objectFit="contain"
+                          />
+                        </div>
+                        <span className="text-[1.4rem] font-normal not-italic leading-[2.2rem] text-gray-50 tablet:text-[1.6rem]">
+                          {shopOriginalData?.address1}{" "}
+                          {shopOriginalData?.address2}
+                        </span>
+                      </div>
+                      <span className="text-black-50 h-[6.6rem] scroll-auto text-[1.4rem] font-normal not-italic leading-[2.2rem] tablet:text-[1.6rem]">
+                        {shopOriginalData?.description}
+                      </span>
+                    </div>
+                    {applyStatus === "pending" ? (
+                      <CancelDialog handleCancel={handleCancel} />
+                    ) : (
+                      <ProfileRegistDialog
+                        handleApply={handleApply}
+                        profile={profile}
+                        pagingProfileRegist={pagingProfileRegist}
+                      />
+                    )}
+                  </div>
+                </div>
+                <div className="flex h-[15.3rem] w-full flex-col items-start gap-[0.8rem] rounded-[1.2rem] bg-gray-10 p-[2rem] tablet:h-[14.8rem]">
+                  <span className="text-black-50 scroll-auto text-[1.4rem] font-bold not-italic leading-[2.2rem] tablet:text-[1.6rem]">
+                    공고 설명
+                  </span>
+                  <span className="text-black-50 scroll-auto text-[1.4rem] font-normal not-italic leading-[2.2rem] tablet:text-[1.6rem]">
+                    {shopNoticeData?.description}
+                  </span>
+                </div>
               </div>
             </div>
-            <div className="flex h-[15.3rem] w-full flex-col items-start gap-[0.8rem] rounded-[1.2rem] bg-gray-10 p-[2rem] tablet:h-[14.8rem]">
-              <span className="text-black-50 scroll-auto text-[1.4rem] font-bold not-italic leading-[2.2rem] tablet:text-[1.6rem]">
-                공고 설명
-              </span>
-              <span className="text-black-50 scroll-auto text-[1.4rem] font-normal not-italic leading-[2.2rem] tablet:text-[1.6rem]">
-                {shopNoticeData?.description}
-              </span>
+            <div className="flex w-full flex-col items-start gap-[1.6rem] bg-[#fafafa] px-[1.2rem] pb-[8rem] pt-[4rem]">
+              <h1 className="text-[2rem] font-bold not-italic leading-normal text-black">
+                최근에 본 공고
+              </h1>
+              <div className="grid grid-cols-2 gap-x-[0.8rem] gap-y-[1.6rem]">
+                {storedRecentNotices.map((notice: any) => (
+                  <div key={notice.id}>
+                    <Link
+                      href={PAGE_ROUTES.parseNotciesApplyURL(
+                        notice.shopdata.id,
+                        notice.noticedata.id,
+                      )}
+                    >
+                      <NoticeApplyItem
+                        item={notice.noticedata}
+                        shopData={notice.shopdata}
+                      />
+                    </Link>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-        </div>
-        <div className="flex w-full flex-col items-start gap-[1.6rem] bg-[#fafafa] px-[1.2rem] pb-[8rem] pt-[4rem]">
-          <h1 className="text-[2rem] font-bold not-italic leading-normal text-black">
-            최근에 본 공고
-          </h1>
-          <div className="grid grid-cols-2 gap-x-[0.8rem] gap-y-[1.6rem]">
-            {storedRecentNotices.map((notice: any) => (
-              <div key={notice.id}>
-                <Link
-                  href={PAGE_ROUTES.parseNotciesApplyURL(
-                    notice.shopdata.id,
-                    notice.noticedata.id,
-                  )}
-                >
-                  <NoticeApplyItem
-                    item={notice.noticedata}
-                    shopData={notice.shopdata}
-                  />
-                </Link>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </EmployeeLayout>
+        </EmployeeLayout>
+      </>
+    )
   );
 }
 

--- a/src/pages/shops/[shopId]/notices/[noticeId]/index.tsx
+++ b/src/pages/shops/[shopId]/notices/[noticeId]/index.tsx
@@ -309,39 +309,41 @@ function NoticeDetail() {
                   상태
                 </span>
               </div>
-              {applicants.map((applicant) => (
-                <React.Fragment key={applicant.id}>
-                  <div className="col-span-1 flex items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-r-[0.1rem] border-t-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem]">
-                    <span className="text-black-50 scroll-auto text-[1.4rem] font-normal not-italic leading-[2.2rem] tablet:text-[1.6rem]">
-                      {applicant.name}
-                    </span>
-                  </div>
-                  <div className="hidden items-center gap-[1.2rem] border-b-[0.1rem] border-r-[0.1rem] bg-white px-[0.8rem] py-[1.2rem] tablet:col-span-1 tablet:block">
-                    <span className="text-black-50 scroll-auto truncate text-[1.6rem] font-normal not-italic leading-[2.6rem]">
-                      {applicant.bio}
-                    </span>
-                  </div>
-                  <div className="hidden items-center gap-[1.2rem] border-b-[0.1rem] border-r-[0.1rem] bg-white px-[0.8rem] py-[1.2rem] desktop:col-span-1 desktop:block">
-                    <span className="text-black-50 scroll-auto truncate text-[1.6rem] font-normal not-italic leading-[2.6rem]">
-                      {applicant.phone}
-                    </span>
-                  </div>
-                  <div className="col-span-1 flex items-center gap-[0.8rem] self-stretch border-b-[0.1rem] border-t-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem] tablet:gap-[1.2rem]">
-                    {applicant.status === "pending" && (
-                      <ApproveDialog
-                        handleApprove={() => handleApprove(applicant.id)}
-                      />
-                    )}
-                    {applicant.status === "pending" && (
-                      <RejectDialog
-                        handleReject={() => handleReject(applicant.id)}
-                      />
-                    )}
-                    {applicant.status === "accepted" && <ApproveBadge />}
-                    {applicant.status === "rejected" && <RejectBadge />}
-                  </div>
-                </React.Fragment>
-              ))}
+              {applicants
+                .filter((applicant) => applicant.status !== "canceled")
+                .map((applicant) => (
+                  <React.Fragment key={applicant.id}>
+                    <div className="col-span-1 flex items-center gap-[1.2rem] self-stretch border-b-[0.1rem] border-r-[0.1rem] border-t-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem]">
+                      <span className="text-black-50 scroll-auto text-[1.4rem] font-normal not-italic leading-[2.2rem] tablet:text-[1.6rem]">
+                        {applicant.name}
+                      </span>
+                    </div>
+                    <div className="hidden items-center gap-[1.2rem] border-b-[0.1rem] border-r-[0.1rem] bg-white px-[0.8rem] py-[1.2rem] tablet:col-span-1 tablet:block">
+                      <span className="text-black-50 scroll-auto truncate text-[1.6rem] font-normal not-italic leading-[2.6rem]">
+                        {applicant.bio}
+                      </span>
+                    </div>
+                    <div className="hidden items-center gap-[1.2rem] border-b-[0.1rem] border-r-[0.1rem] bg-white px-[0.8rem] py-[1.2rem] desktop:col-span-1 desktop:block">
+                      <span className="text-black-50 scroll-auto truncate text-[1.6rem] font-normal not-italic leading-[2.6rem]">
+                        {applicant.phone}
+                      </span>
+                    </div>
+                    <div className="col-span-1 flex items-center gap-[0.8rem] self-stretch border-b-[0.1rem] border-t-[0.1rem] border-gray-20 bg-white px-[0.8rem] py-[1.2rem] tablet:gap-[1.2rem]">
+                      {applicant.status === "pending" && (
+                        <ApproveDialog
+                          handleApprove={() => handleApprove(applicant.id)}
+                        />
+                      )}
+                      {applicant.status === "pending" && (
+                        <RejectDialog
+                          handleReject={() => handleReject(applicant.id)}
+                        />
+                      )}
+                      {applicant.status === "accepted" && <ApproveBadge />}
+                      {applicant.status === "rejected" && <RejectBadge />}
+                    </div>
+                  </React.Fragment>
+                ))}
             </div>
             <div className="flex h-[5.6rem] w-full items-center justify-center">
               <ApplyListPagination


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: 알바님 - 공고 상세 페이지(로그인 상태): 이미 신청한 공고에서 신청에서 취소하기 기능 필요
- 신청 취소할 때 보이는 모달창 필요
- 신청 시 프로필 없을 때 프로필등록 페이지로 이동시키는 기능과 모달창 필요
- 공고상세페이지(로그인 상태)에서 새로고침할 때 생기는 오류 수정 필요

# 어떤 변화가 생겼나요?

- 신청한 공고상세페이지에서 취소하기 버튼을 누르면 공고신청이 취소되는 기능 구현
- 신청 시 프로필 없을 때 프로필등록 페이지로 이동시키는 기능과 모달창 구현 
- 공고상세페이지(로그인 상태)에서 새로고침할 때 생기는 오류는 더이상 뜨지 않음.

# 문제가 있나요?
- 신청한 공고 취소 시 네트워크 상태를 통해 신청 status가 정상적으로 put되어 canceled된 걸 확인 가능, 하지만 바로 적용되지 않고 새로고침해야 리렌더링이 일어남
- 공고상세페이지(로그인 상태)에서 새로고침할 때 생기는 오류는 막았지만 공고리스트페이지로 리다이렉트됨. 
- 공고상세페이지(사장님)에서 canceled인 신청들도 신청자 목록을 차지하고 있음. 보이진 않지만 자리를 차지함

# 스크린샷(optional)

