### PR TITLE
내 프로필: 내 프로필 페이지에 유저 타입 체킹 추가

### DIFF
--- a/src/pages/my/edit/index.tsx
+++ b/src/pages/my/edit/index.tsx
@@ -1,9 +1,22 @@
+import { useRouter } from "next/router";
+import { useContext, useEffect } from "react";
+
 import EmployeeLayout from "@/components/common/EmployeeLayout";
 import ErrorDialog from "@/components/common/ErrorDialog";
 import MyEditForm from "@/components/my/MyEditForm";
+import { getAccessTokenInStorage } from "@/helpers/auth";
 import ErrorDialogProvider from "@/providers/ErrorDialogProvider";
+import { UserContext } from "@/providers/UserProvider";
+import { PAGE_ROUTES } from "@/routes";
 
 export default function MyEdit() {
+  const router = useRouter();
+  const user = useContext(UserContext);
+  useEffect(() => {
+    if (!getAccessTokenInStorage()) router.push(PAGE_ROUTES.SIGNIN);
+    if (user?.type === "employer") router.push(PAGE_ROUTES.NOTICES);
+  }, [router, user?.type]);
+
   return (
     <ErrorDialogProvider>
       <EmployeeLayout>

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -15,7 +15,10 @@ export default function My() {
 
   useEffect(() => {
     if (!getAccessTokenInStorage()) router.push(PAGE_ROUTES.SIGNIN);
-  }, [router]);
+    if (user?.type === "employer") {
+      router.push(PAGE_ROUTES.NOTICES);
+    }
+  }, [router, user?.type]);
 
   const profile =
     user && user.name && user.phone && user.address

--- a/src/pages/my/register/index.tsx
+++ b/src/pages/my/register/index.tsx
@@ -1,9 +1,22 @@
+import { useRouter } from "next/router";
+import { useContext, useEffect } from "react";
+
 import EmployeeLayout from "@/components/common/EmployeeLayout";
 import ErrorDialog from "@/components/common/ErrorDialog";
 import RegisterForm from "@/components/my/RegisterForm";
+import { getAccessTokenInStorage } from "@/helpers/auth";
 import ErrorDialogProvider from "@/providers/ErrorDialogProvider";
+import { UserContext } from "@/providers/UserProvider";
+import { PAGE_ROUTES } from "@/routes";
 
 export default function MyRegister() {
+  const router = useRouter();
+  const user = useContext(UserContext);
+  useEffect(() => {
+    if (!getAccessTokenInStorage()) router.push(PAGE_ROUTES.SIGNIN);
+    if (user?.type === "employer") router.push(PAGE_ROUTES.NOTICES);
+  }, [router, user?.type]);
+
   return (
     <ErrorDialogProvider>
       <EmployeeLayout>


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: #258 
-

# 어떤 변화가 생겼나요?

- 내 프로필 페이지에 유저 타입 체킹 추가
- 내 프로필 등록 페이지에 유저 타입, 로그인 여부 체킹 추가
- 내 프로필 수정 페이지에 유저 타입, 로그인 여부 체킹 추가

# 스크린샷(optional)
